### PR TITLE
Allow to directly specify #[tanu::test] without import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,6 +1917,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "test-case",
  "walkdir",
 ]
 
@@ -1956,6 +1957,39 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+test-case = "3"

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use std::collections::HashMap;
-use tanu::{assert_eq, http::Client, test};
+use tanu::{assert_eq, http::Client};
 
 #[derive(Debug, Deserialize)]
 struct Payload {
@@ -10,7 +10,7 @@ struct Payload {
     url: url::Url,
 }
 
-#[test]
+#[tanu::test]
 async fn get() -> eyre::Result<()> {
     let http = Client::new();
     let res = http.get("https://httpbin.org/get").send().await?;

--- a/tanu-derive/Cargo.toml
+++ b/tanu-derive/Cargo.toml
@@ -19,5 +19,8 @@ quote = "1"
 syn = { version = "2", features = ["full"] }
 walkdir = "2.5"
 
+[dev-dependencies]
+test-case = { workspace = true }
+
 [lib]
 proc-macro = true


### PR DESCRIPTION
this is now supported
```rust
#[tanu::test]
fn foo() {
}
```

as well as this
```rust
use tanu::test;

#[test]
fn foo() {
}
```