### PR TITLE
Improve backtrace when the test is using eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,6 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 name = "simple"
 version = "0.1.0"
 dependencies = [
- "eyre",
  "serde",
  "tanu",
  "tokio",

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-eyre = { workspace = true }
 serde = { workspace = true }
 tanu = { path = "../../tanu" }
 tokio = { workspace = true }

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use std::collections::HashMap;
-use tanu::{assert_eq, http::Client};
+use tanu::{assert_eq, eyre, http::Client};
 
 #[derive(Debug, Deserialize)]
 struct Payload {


### PR DESCRIPTION
if a test function uses eyre, it does not wrap in another eyre Result, so that full backtrace is preserved.