### PR TITLE
Support defining same test name in different modules

### DIFF
--- a/tanu-derive/src/lib.rs
+++ b/tanu-derive/src/lib.rs
@@ -299,21 +299,13 @@ pub fn test(args: TokenStream, input: TokenStream) -> TokenStream {
     let func_name_inner = &input_fn.sig.ident;
     let test_case = TestCase::from_func_name(&input_args, &func_name_inner.to_string());
 
-    let duplicated = match TEST_CASES.lock() {
-        Ok(mut lock) => !lock.insert(test_case.clone()),
+    match TEST_CASES.lock() {
+        Ok(mut lock) => lock.insert(test_case.clone()),
         Err(e) => {
             eprintln!("Failed to acquire test case lock: {}", e);
             return quote! { #input_fn }.into();
         }
     };
-
-    if duplicated {
-        eprintln!(
-            r#"tanu does not yet support registering test with the exactly same signature.
- please check the name of this function "{func_name_inner}" and try again."#
-        );
-        return quote! { #input_fn }.into();
-    }
 
     let func_name = Ident::new(&test_case.func_name, Span::call_site());
     let args = input_args.args.to_token_stream();
@@ -469,7 +461,10 @@ pub fn main(_args: TokenStream, input: TokenStream) -> TokenStream {
     let main_fn = parse_macro_input!(input as ItemFn);
 
     let test_modules = discover_tests().expect("failed to discover test cases");
-    let test_modules: HashMap<String, String> = test_modules
+    // Create a HashMap mapping test function names to their module paths.
+    // Using Vec<String> as the value allows multiple test functions with the same name
+    // to exist across different modules.
+    let test_modules: HashMap<String, Vec<String>> = test_modules
         .iter()
         .flat_map(|module| {
             let module_name = module.module.clone();
@@ -484,33 +479,34 @@ pub fn main(_args: TokenStream, input: TokenStream) -> TokenStream {
                 )
             })
         })
-        .collect();
+        .fold(HashMap::new(), |mut acc, (func_name, module_name)| {
+            acc.entry(func_name).or_default().push(module_name);
+            acc
+        });
 
     let (test_mods, test_names, func_names): (Vec<_>, Vec<_>, Vec<_>) = match TEST_CASES.lock() {
         Ok(lock) => lock
             .iter()
-            .filter_map(|f| {
-                let test_module = match test_modules.get(&f.func_name) {
-                    Some(module) => module,
-                    None => {
-                        eprintln!("module not found for function: {}", f.func_name);
-                        return None;
-                    }
-                };
+            .flat_map(|f| {
+                test_modules
+                    .get(&f.func_name)
+                    .into_iter() // This safely handles None by returning an empty iterator
+                    .flatten() // Flatten the Vec<String> to String
+                    .filter_map(|module_name| {
+                        let test_module_path = match syn::parse_str::<syn::Path>(module_name) {
+                            Ok(path) => path,
+                            Err(e) => {
+                                eprintln!("failed to parse module path '{module_name}': {e}");
+                                return None;
+                            }
+                        };
 
-                let test_module_path = match syn::parse_str::<syn::Path>(test_module) {
-                    Ok(path) => path,
-                    Err(e) => {
-                        eprintln!("failed to parse module path '{test_module}': {e}");
-                        return None;
-                    }
-                };
-
-                Some((
-                    test_module_path,
-                    f.test_name.clone(),
-                    Ident::new(&f.func_name, Span::call_site()),
-                ))
+                        Some((
+                            test_module_path,
+                            f.test_name.clone(),
+                            Ident::new(&f.func_name, Span::call_site()),
+                        ))
+                    })
             })
             .multiunzip(),
         Err(e) => {

--- a/tanu-integration-tests/src/http/get.rs
+++ b/tanu-integration-tests/src/http/get.rs
@@ -82,3 +82,8 @@ async fn bearer_auth() -> eyre::Result<()> {
     assert_eq!("token", payload.token);
     Ok(())
 }
+
+#[tanu::test]
+async fn same_test_name_in_different_modules() -> eyre::Result<()> {
+    Ok(())
+}

--- a/tanu-integration-tests/src/macros.rs
+++ b/tanu-integration-tests/src/macros.rs
@@ -221,3 +221,8 @@ async fn with_none(_: Option<u8>) -> eyre::Result<()> {
 async fn with_function_call_chain(_: usize) -> eyre::Result<()> {
     Ok(())
 }
+
+#[tanu::test]
+async fn same_test_name_in_different_modules() -> eyre::Result<()> {
+    Ok(())
+}

--- a/tanu-integration-tests/src/main.rs
+++ b/tanu-integration-tests/src/main.rs
@@ -1,5 +1,6 @@
 mod http;
 mod macros;
+mod misc;
 
 use tanu::eyre;
 

--- a/tanu-integration-tests/src/misc.rs
+++ b/tanu-integration-tests/src/misc.rs
@@ -1,0 +1,6 @@
+use tanu::eyre;
+
+#[tanu::test]
+async fn same_test_name_in_different_modules() -> eyre::Result<()> {
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces changes to the `tanu-derive` crate and its integration tests to allow test functions with the same name to exist across different modules. Key changes include modifying the test registration logic, updating the handling of test cases in the `main` function, and adding new test cases to validate the functionality.

### Changes to test registration and handling:

* Removed the restriction that prevented registering test functions with identical names. The `test` function no longer checks for duplicate test names, allowing multiple tests with the same name to be registered. (`tanu-derive/src/lib.rs`, [tanu-derive/src/lib.rsL302-L317](diffhunk://#diff-b21e9e03fc54fce1c29ed7310041b5202a928fda030124a11d64beb7ce387b26L302-L317))
* Updated the `main` function to use a `HashMap<String, Vec<String>>` for mapping test function names to their respective module paths. This enables support for multiple test functions with the same name across different modules. (`tanu-derive/src/lib.rs`, [[1]](diffhunk://#diff-b21e9e03fc54fce1c29ed7310041b5202a928fda030124a11d64beb7ce387b26L472-R467) [[2]](diffhunk://#diff-b21e9e03fc54fce1c29ed7310041b5202a928fda030124a11d64beb7ce387b26L487-R501)

### Integration tests:

* Added new test cases named `same_test_name_in_different_modules` in multiple modules (`http`, `macros`, and `misc`) to verify that the updated functionality works as expected. (`tanu-integration-tests/src/http/get.rs`, [[1]](diffhunk://#diff-e2a178b2e636784fd07bb79f7d3c86e5a077efe2d0eb6852e8f2a5b64dfd2180R85-R89); `tanu-integration-tests/src/macros.rs`, [[2]](diffhunk://#diff-73a7cb04f0e9a53387fb75da9fe6fb9dbba681891b97c49fede5572323fa5f46R224-R228); `tanu-integration-tests/src/misc.rs`, [[3]](diffhunk://#diff-a215db0aa0ef6e56e3c24e6163815ba40cc558d11a875f89633fbe5bb77ffd43R1-R6)
* Added a new `misc` module to the integration tests to include additional test cases. (`tanu-integration-tests/src/main.rs`, [tanu-integration-tests/src/main.rsR3](diffhunk://#diff-5a308b3d0d954e160408432b0bfb206acad3dcc7bcf99a8784b95313b6c50d43R3))