### PR TITLE
Add semaphore to control concurrency

### DIFF
--- a/docs/command-line-option.md
+++ b/docs/command-line-option.md
@@ -12,6 +12,7 @@ Run tests with tanu.
 * `-m, --modules <MODULES>`    Run only the specified modules. This option can be specified multiple times e.g. --modules foo --modules bar
 * `-t, --tests <TESTS>`        Run only the specified test cases. This option can be specified multiple times e.g. --tests a ---tests b
 * `--reporter <REPORTER>`  Specify the reporter to use. Default is "table". Possible values are "table", "list" and "null"
+* `-c, --concurrency <NUMBER>` Specify the maximum number of tests to run in parallel. When unspecified, all tests run in parallel.
 
 ### `tui`
 Launch the TUI (Text User Interface) for tanu.
@@ -19,6 +20,7 @@ Launch the TUI (Text User Interface) for tanu.
 #### Options
 * `--log-level <LOG_LEVEL>`            [default: Info]
 * `--tanu-log-level <TANU_LOG_LEVEL>`  [default: Info]
+* `-c, --concurrency <NUMBER>` Specify the maximum number of tests to run in parallel. Default is the number of logical CPU cores
 
 ### `ls`
 List test cases.

--- a/tanu-tui/src/lib.rs
+++ b/tanu-tui/src/lib.rs
@@ -762,7 +762,9 @@ impl Runtime {
             tokio::select! {
                 _ = draw_interval.tick() => {
                     model.fps_counter.update();
+                    let start_draw = std::time::Instant::now();
                     terminal.draw(|frame| view(&mut model, frame))?;
+                    trace!("Took {:?} to draw", start_draw.elapsed());
                 },
                 _ = cmds_interval.tick() => {
                     let Some(cmd) = cmds.pop_front() else {

--- a/tanu/Cargo.toml
+++ b/tanu/Cargo.toml
@@ -20,6 +20,7 @@ eyre = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+num_cpus = "1"
 once_cell = { workspace = true }
 pretty_assertions = "1"
 reqwest = { version = "0.12", optional = true }


### PR DESCRIPTION
When running tests in TUI, it often hits 100% CPU usage, resulting in UI freeze. Adding semaphore to controll concurrency to resolve that issue.