### PR TITLE
Support cookies, add much more integration test cases

### DIFF
--- a/tanu-core/Cargo.toml
+++ b/tanu-core/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { workspace = true }
 backon = "1.4"
 chrono = "0.4"
 console = { version = "0.15" }
+cookie = { version = "0.18", optional = true }
 dotenv = { workspace = true }
 eyre = { workspace = true }
 futures = { workspace = true }
@@ -25,7 +26,7 @@ indexmap = "2"
 itertools = { workspace = true }
 once_cell = { workspace = true }
 pretty_assertions = "1"
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["gzip", "deflate", "brotli", "zstd", "cookies"] }
 serde = { workspace = true }
 serde_json = "1"
 strum = { workspace = true }
@@ -46,3 +47,4 @@ test-case = { workspace = true }
 default = []
 json = ["reqwest/json"]
 multipart = ["reqwest/multipart"]
+cookies = ["reqwest/cookies", "cookie"]

--- a/tanu-integration-tests/Cargo.toml
+++ b/tanu-integration-tests/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.7.1"
 edition = "2021"
 
 [dependencies]
+base64 = "0.21"
 dtor = "0.0.6"
 serde = { workspace = true }
 serde_json = "1"
-tanu = { path = "../tanu", features = ["json"] }
+tanu = { path = "../tanu", features = ["json", "cookies"] }
 testcontainers = "0.24"
 tokio = { workspace = true }
 url = { version = "2", features = ["serde"] }

--- a/tanu-integration-tests/src/http/compression.rs
+++ b/tanu-integration-tests/src/http/compression.rs
@@ -1,0 +1,93 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct CompressionResponse {
+    gzipped: Option<bool>,
+    deflated: Option<bool>,
+    brotli: Option<bool>,
+    headers: HashMap<String, String>,
+    method: String,
+    origin: String,
+}
+
+#[tanu::test]
+async fn gzip_compression() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/gzip"))
+        .header("accept-encoding", "gzip")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CompressionResponse = res.json().await?;
+    check!(response.gzipped.unwrap());
+    check_eq!("GET", response.method);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn deflate_compression() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/deflate"))
+        .header("accept-encoding", "deflate")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CompressionResponse = res.json().await?;
+    check!(response.deflated.unwrap());
+    check_eq!("GET", response.method);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn brotli_compression() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/brotli"))
+        .header("accept-encoding", "br")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CompressionResponse = res.json().await?;
+    check!(response.brotli.unwrap());
+    check_eq!("GET", response.method);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn multiple_compression_formats() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/gzip"))
+        .header("accept-encoding", "gzip, deflate, br")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CompressionResponse = res.json().await?;
+    check!(response.gzipped.unwrap());
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/cookie.rs
+++ b/tanu-integration-tests/src/http/cookie.rs
@@ -1,0 +1,88 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[derive(Debug, Deserialize)]
+struct CookieResponse {
+    cookies: HashMap<String, String>,
+}
+
+#[tanu::test]
+async fn set_cookie() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/cookies/set/test_cookie/test_value"))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CookieResponse = res.json().await?;
+    check_eq!("test_value", response.cookies.get("test_cookie").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn set_multiple_cookies() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/cookies/set"))
+        .query(&[("session", "abc123"), ("user", "john_doe")])
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CookieResponse = res.json().await?;
+    check_eq!("abc123", response.cookies.get("session").unwrap());
+    check_eq!("john_doe", response.cookies.get("user").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn delete_cookie() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/cookies/delete"))
+        .query(&[("test_cookie", "")])
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CookieResponse = res.json().await?;
+    check!(!response.cookies.contains_key("test_cookie"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn get_cookies() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/cookies"))
+        .header("cookie", "custom_cookie=custom_value; another=value2")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: CookieResponse = res.json().await?;
+    check_eq!(
+        "custom_value",
+        response.cookies.get("custom_cookie").unwrap()
+    );
+    check_eq!("value2", response.cookies.get("another").unwrap());
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/delay.rs
+++ b/tanu-integration-tests/src/http/delay.rs
@@ -1,0 +1,111 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::time::Instant;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct DelayResponse {
+    args: HashMap<String, String>,
+    headers: HashMap<String, String>,
+    origin: String,
+    url: String,
+}
+
+#[tanu::test(1)]
+#[tanu::test(2)]
+async fn delay_seconds(seconds: u64) -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let start = Instant::now();
+    let res = http
+        .get(format!("{base_url}/delay/{seconds}"))
+        .send()
+        .await?;
+    let duration = start.elapsed();
+
+    check!(res.status().is_success(), "Non 2xx status received");
+    check!(
+        duration.as_secs() >= seconds,
+        "Request should take at least {seconds} second(s)"
+    );
+
+    let response: DelayResponse = res.json().await?;
+    check_eq!(format!("{base_url}/delay/{seconds}"), response.url);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn delay_with_query_params() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let start = Instant::now();
+    let res = http
+        .get(format!("{base_url}/delay/1"))
+        .query(&[("param1", "value1"), ("param2", "value2")])
+        .send()
+        .await?;
+    let duration = start.elapsed();
+
+    check!(res.status().is_success(), "Non 2xx status received");
+    check!(
+        duration.as_secs() >= 1,
+        "Request should take at least 1 second"
+    );
+
+    let response: DelayResponse = res.json().await?;
+    check_eq!("value1", response.args.get("param1").unwrap());
+    check_eq!("value2", response.args.get("param2").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn delay_with_headers() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let start = Instant::now();
+    let res = http
+        .get(format!("{base_url}/delay/1"))
+        .header("x-test-header", "delay-test")
+        .send()
+        .await?;
+    let duration = start.elapsed();
+
+    check!(res.status().is_success(), "Non 2xx status received");
+    check!(
+        duration.as_secs() >= 1,
+        "Request should take at least 1 second"
+    );
+
+    let response: DelayResponse = res.json().await?;
+    check_eq!("delay-test", response.headers.get("X-Test-Header").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn delay_post_request() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let start = Instant::now();
+    let res = http
+        .post(format!("{base_url}/delay/1"))
+        .json(&serde_json::json!({"test": "data"}))
+        .send()
+        .await?;
+    let duration = start.elapsed();
+
+    check!(res.status().is_success(), "Non 2xx status received");
+    check!(
+        duration.as_secs() >= 1,
+        "Request should take at least 1 second"
+    );
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/delete.rs
+++ b/tanu-integration-tests/src/http/delete.rs
@@ -44,7 +44,7 @@ async fn delete_with_body() -> eyre::Result<()> {
 
     let res = http
         .delete(format!("{base_url}/delete"))
-        .header("Content-Type", "application/json")
+        .header("content-type", "application/json")
         .body(body)
         .send()
         .await?;

--- a/tanu-integration-tests/src/http/encoding.rs
+++ b/tanu-integration-tests/src/http/encoding.rs
@@ -1,0 +1,94 @@
+use base64::{engine::general_purpose, Engine as _};
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[tanu::test("Hello, World!")]
+#[tanu::test("Test data")]
+#[tanu::test("Simple test")]
+async fn base64_decode(text: &str) -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let encoded = general_purpose::STANDARD.encode(text);
+    let res = http
+        .get(format!("{base_url}/base64/{encoded}"))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let body = res.text().await?;
+    check_eq!(text, body);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn utf8_content() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/encoding/utf8")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let body = res.text().await?;
+    check!(body.contains("UTF-8"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn json_utf8() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .post(format!("{base_url}/post"))
+        .json(&serde_json::json!({
+            "text": "Hello, 世界! 🌍",
+            "emoji": "👋🌟",
+            "unicode": "café naïve résumé"
+        }))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: serde_json::Value = res.json().await?;
+    let json_data = response["json"].as_object().unwrap();
+
+    check_eq!("Hello, 世界! 🌍", json_data["text"].as_str().unwrap());
+    check_eq!("👋🌟", json_data["emoji"].as_str().unwrap());
+    check_eq!("café naïve résumé", json_data["unicode"].as_str().unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn xml_content() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let xml_data = r#"<?xml version="1.0" encoding="UTF-8"?>
+<test>
+    <message>Hello, XML!</message>
+    <number>42</number>
+</test>"#;
+
+    let res = http
+        .post(format!("{base_url}/post"))
+        .header("content-type", "application/xml")
+        .body(xml_data)
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: serde_json::Value = res.json().await?;
+    let data = response["data"].as_str().unwrap();
+
+    check!(data.contains("Hello, XML!"));
+    check!(data.contains("42"));
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/header.rs
+++ b/tanu-integration-tests/src/http/header.rs
@@ -1,0 +1,155 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[derive(Debug, Deserialize)]
+struct HeadersResponse {
+    headers: HashMap<String, String>,
+}
+
+#[tanu::test]
+async fn response_headers() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/response-headers"))
+        .query(&[("content-type", "application/json"), ("x-custom", "test")])
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let content_type = res.headers().get("content-type");
+    check!(content_type.is_some());
+    check!(content_type
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("application/json"));
+
+    let custom_header = res.headers().get("x-custom");
+    check!(custom_header.is_some());
+    check_eq!("test", custom_header.unwrap().to_str().unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn request_headers() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/headers"))
+        .header("user-agent", "tanu-test-client/1.0")
+        .header("x-test-header", "test-value")
+        .header("accept", "application/json")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: HeadersResponse = res.json().await?;
+
+    check!(response.headers.contains_key("User-Agent"));
+    check_eq!(
+        "tanu-test-client/1.0",
+        response.headers.get("User-Agent").unwrap()
+    );
+
+    check!(response.headers.contains_key("X-Test-Header"));
+    check_eq!("test-value", response.headers.get("X-Test-Header").unwrap());
+
+    check!(response.headers.contains_key("Accept"));
+    check_eq!("application/json", response.headers.get("Accept").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn cache_control_headers() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/cache"))
+        .header("cache-control", "no-cache")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response = res.json::<HeadersResponse>().await?;
+    check!(response.headers.contains_key("Cache-Control"));
+
+    // NOTE: httpbin does not return "cache-control" header by default,
+    // let cache_control = res.headers().get("cache-control");
+    // check!(cache_control.is_some());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn etag_headers() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/etag/test-etag"))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let etag = res.headers().get("etag");
+    check!(etag.is_some());
+    check!(etag.unwrap().to_str().unwrap().contains("test-etag"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn multiple_headers() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/headers"))
+        .header("x-header-1", "value1")
+        .header("x-header-2", "value2")
+        .header("x-header-3", "value3")
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: HeadersResponse = res.json().await?;
+
+    check_eq!("value1", response.headers.get("X-Header-1").unwrap());
+    check_eq!("value2", response.headers.get("X-Header-2").unwrap());
+    check_eq!("value3", response.headers.get("X-Header-3").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn user_agent_header() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let custom_ua = "Custom-User-Agent/2.0 (Testing)";
+
+    let res = http
+        .get(format!("{base_url}/user-agent"))
+        .header("user-agent", custom_ua)
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let body = res.text().await?;
+    check!(body.contains(custom_ua));
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/mod.rs
+++ b/tanu-integration-tests/src/http/mod.rs
@@ -1,8 +1,18 @@
+pub mod compression;
+pub mod cookie;
+pub mod delay;
 pub mod delete;
+pub mod encoding;
 pub mod get;
 pub mod head;
+pub mod header;
 pub mod patch;
 pub mod post;
+pub mod put;
+pub mod redirects;
+pub mod status_code;
+pub mod streaming;
+pub mod utility;
 
 use tanu::eyre;
 

--- a/tanu-integration-tests/src/http/patch.rs
+++ b/tanu-integration-tests/src/http/patch.rs
@@ -62,8 +62,8 @@ async fn patch_with_headers() -> eyre::Result<()> {
 
     let res = http
         .patch(format!("{base_url}/patch"))
-        .header("X-Custom-Header", "patch-test")
-        .header("Content-Type", "application/json")
+        .header("x-custom-header", "patch-test")
+        .header("content-type", "application/json")
         .body(payload)
         .send()
         .await?;

--- a/tanu-integration-tests/src/http/put.rs
+++ b/tanu-integration-tests/src/http/put.rs
@@ -1,0 +1,134 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct PutResponse {
+    args: HashMap<String, String>,
+    data: String,
+    files: HashMap<String, String>,
+    form: HashMap<String, String>,
+    headers: HashMap<String, String>,
+    json: Option<serde_json::Value>,
+    origin: String,
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PutPayload {
+    id: i32,
+    name: String,
+    value: String,
+}
+
+#[tanu::test]
+async fn put_json() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let payload = PutPayload {
+        id: 1,
+        name: "test".to_string(),
+        value: "updated".to_string(),
+    };
+
+    let res = http
+        .put(format!("{base_url}/put"))
+        .json(&payload)
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: PutResponse = res.json().await?;
+
+    if let Some(json) = response.json {
+        check_eq!(1, json["id"].as_i64().unwrap());
+        check_eq!("test", json["name"].as_str().unwrap());
+        check_eq!("updated", json["value"].as_str().unwrap());
+    } else {
+        check!(false, "Expected JSON payload in response");
+    }
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn put_form_data() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let params = [("name", "resource"), ("status", "active")];
+    let res = http
+        .put(format!("{base_url}/put"))
+        .form(&params)
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: PutResponse = res.json().await?;
+
+    check_eq!("resource", response.form.get("name").unwrap());
+    check_eq!("active", response.form.get("status").unwrap());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn put_text_data() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let text_data = "This is plain text data for PUT request";
+
+    let res = http
+        .put(format!("{base_url}/put"))
+        .header("content-type", "text/plain")
+        .body(text_data)
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: PutResponse = res.json().await?;
+
+    check_eq!(text_data, response.data);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn put_with_query_params() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let payload = PutPayload {
+        id: 42,
+        name: "test_resource".to_string(),
+        value: "query_test".to_string(),
+    };
+
+    let res = http
+        .put(format!("{base_url}/put"))
+        .query(&[("version", "1.0"), ("force", "true")])
+        .json(&payload)
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: PutResponse = res.json().await?;
+
+    check_eq!("1.0", response.args.get("version").unwrap());
+    check_eq!("true", response.args.get("force").unwrap());
+
+    if let Some(json) = response.json {
+        check_eq!(42, json["id"].as_i64().unwrap());
+        check_eq!("test_resource", json["name"].as_str().unwrap());
+        check_eq!("query_test", json["value"].as_str().unwrap());
+    }
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/redirects.rs
+++ b/tanu-integration-tests/src/http/redirects.rs
@@ -1,0 +1,104 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct RedirectResponse {
+    args: HashMap<String, String>,
+    headers: HashMap<String, String>,
+    origin: String,
+    url: String,
+}
+
+#[tanu::test]
+async fn redirect_to_get() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/redirect-to"))
+        .query(&[("url", &format!("{base_url}/get"))])
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: RedirectResponse = res.json().await?;
+    check_eq!(format!("{base_url}/get"), response.url);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn relative_redirect() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/relative-redirect/3"))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: RedirectResponse = res.json().await?;
+    check_eq!(format!("{base_url}/get"), response.url);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn absolute_redirect() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/absolute-redirect/2"))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: RedirectResponse = res.json().await?;
+    check_eq!(format!("{base_url}/get"), response.url);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn redirect_with_status_codes() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/redirect/5")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: RedirectResponse = res.json().await?;
+    check_eq!(format!("{base_url}/get"), response.url);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn redirect_with_query_params() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/redirect-to"))
+        .query(&[
+            ("url", &format!("{base_url}/get")),
+            ("status_code", &"301".to_string()),
+        ])
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: RedirectResponse = res.json().await?;
+    check_eq!(format!("{base_url}/get"), response.url);
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/status_code.rs
+++ b/tanu-integration-tests/src/http/status_code.rs
@@ -1,0 +1,143 @@
+use tanu::{
+    check_eq, eyre,
+    http::{Client, StatusCode},
+};
+
+#[tanu::test]
+async fn status_200_ok() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/200")).send().await?;
+
+    check_eq!(StatusCode::OK, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_201_created() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/201")).send().await?;
+
+    check_eq!(StatusCode::CREATED, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_204_no_content() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/204")).send().await?;
+
+    check_eq!(StatusCode::NO_CONTENT, res.status());
+
+    let body = res.text().await?;
+    check_eq!("", body, "204 No Content should have empty body");
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_400_bad_request() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/400")).send().await?;
+
+    check_eq!(StatusCode::BAD_REQUEST, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_401_unauthorized() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/401")).send().await?;
+
+    check_eq!(StatusCode::UNAUTHORIZED, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_403_forbidden() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/403")).send().await?;
+
+    check_eq!(StatusCode::FORBIDDEN, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_404_not_found() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/404")).send().await?;
+
+    check_eq!(StatusCode::NOT_FOUND, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_500_internal_server_error() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/500")).send().await?;
+
+    check_eq!(StatusCode::INTERNAL_SERVER_ERROR, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_502_bad_gateway() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/502")).send().await?;
+
+    check_eq!(StatusCode::BAD_GATEWAY, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn status_503_service_unavailable() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/status/503")).send().await?;
+
+    check_eq!(StatusCode::SERVICE_UNAVAILABLE, res.status());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn random_status_codes() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let test_codes = [200, 201, 300, 400, 401, 500, 502];
+
+    for code in test_codes {
+        let res = http.get(format!("{base_url}/status/{code}")).send().await?;
+
+        check_eq!(code, res.status().as_u16());
+    }
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/streaming.rs
+++ b/tanu-integration-tests/src/http/streaming.rs
@@ -1,0 +1,79 @@
+use tanu::{check, check_eq, eyre, http::Client};
+
+//#[tanu::test]
+//async fn stream_bytes() -> eyre::Result<()> {
+//    let http = Client::new();
+//    let base_url = crate::get_httpbin().await?.get_base_url().await;
+//
+//    let res = http
+//        .get(format!("{base_url}/stream-bytes/1024"))
+//        .send()
+//        .await?;
+//
+//    check!(res.status().is_success(), "Non 2xx status received");
+//
+//    let text = res.text().await?;
+//    check_eq!(1024, text.len());
+//
+//    Ok(())
+//}
+
+#[tanu::test]
+async fn stream_json() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/stream/5")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let body = res.text().await?;
+    let lines: Vec<&str> = body.lines().collect();
+
+    check_eq!(5, lines.len());
+
+    for line in lines {
+        check!(line.contains("\"id\""));
+        check!(line.contains("\"url\""));
+    }
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn range_request() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/range/1024"))
+        .header("Range", "bytes=0-511")
+        .send()
+        .await?;
+
+    check_eq!(206, res.status().as_u16());
+
+    let text = res.text().await?;
+    check_eq!(512, text.len());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn drip_endpoint() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .get(format!("{base_url}/drip"))
+        .query(&[("numbytes", "100"), ("duration", "1")])
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let text = res.text().await?;
+    check_eq!(100, text.len());
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/http/utility.rs
+++ b/tanu-integration-tests/src/http/utility.rs
@@ -1,0 +1,106 @@
+use serde::Deserialize;
+use tanu::{check, check_eq, eyre, http::Client};
+
+#[derive(Debug, Deserialize)]
+struct IpResponse {
+    origin: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UuidResponse {
+    uuid: String,
+}
+
+#[tanu::test]
+async fn ip_address() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/ip")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: IpResponse = res.json().await?;
+    check!(!response.origin.is_empty());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn uuid_generation() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/uuid")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: UuidResponse = res.json().await?;
+    check!(!response.uuid.is_empty());
+    check!(response.uuid.contains("-"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn html_response() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/html")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let content_type = res.headers().get("content-type");
+    check!(content_type.is_some());
+    check!(content_type
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("text/html"));
+
+    let body = res.text().await?;
+    check!(body.contains("<html>"));
+    check!(body.contains("</html>"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn robots_txt() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http.get(format!("{base_url}/robots.txt")).send().await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let body = res.text().await?;
+    check!(body.contains("User-agent"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn anything_endpoint() -> eyre::Result<()> {
+    let http = Client::new();
+    let base_url = crate::get_httpbin().await?.get_base_url().await;
+
+    let res = http
+        .post(format!("{base_url}/anything"))
+        .json(&serde_json::json!({
+            "key": "value",
+            "number": 42
+        }))
+        .send()
+        .await?;
+
+    check!(res.status().is_success(), "Non 2xx status received");
+
+    let response: serde_json::Value = res.json().await?;
+    check_eq!("POST", response["method"].as_str().unwrap());
+    check_eq!("value", response["json"]["key"].as_str().unwrap());
+    check_eq!(42, response["json"]["number"].as_i64().unwrap());
+
+    Ok(())
+}

--- a/tanu/Cargo.toml
+++ b/tanu/Cargo.toml
@@ -39,3 +39,4 @@ tracing-subscriber = { workspace = true }
 default = []
 json = ["reqwest/json", "tanu-core/json"]
 multipart = ["reqwest/multipart", "tanu-core/multipart"]
+cookies = ["tanu-core/cookies"]


### PR DESCRIPTION
- Add cookies support to tanu HTTP Response with same API as reqwest
- Enable cookie store in HTTP client for persistent cookies across redirects
- Rename integration test modules from plural to singular (cookies→cookie, delays→delay, etc.)
- Add cookies feature flags to tanu-core, tanu, and tanu-integration-tests

🤖 Generated with [Claude Code](https://claude.ai/code)