### PR TITLE
Fix macro imports to use absolute paths for Error type

### DIFF
--- a/tanu-core/src/assertion.rs
+++ b/tanu-core/src/assertion.rs
@@ -137,7 +137,7 @@ macro_rules! check_str_eq {
                     );
                     let __check = tanu::runner::Check::error(&__message);
                     tanu::runner::publish(tanu::runner::EventBody::Check(Box::new(__check)))?;
-                    Err(Error::StrEq(__message))?;
+                    Err(tanu::assertion::Error::StrEq(__message))?;
                 } else {
                     let __message = format!("check succeeded: `(left == right)`{}{}\
                        \n\
@@ -298,7 +298,7 @@ macro_rules! check_ne {
                     );
                     let __check = tanu::runner::Check::error(&__message);
                     tanu::runner::publish(tanu::runner::EventBody::Check(Box::new(__check)))?;
-                    Err(Error::Ne(__message))?;
+                    Err(tanu::assertion::Error::Ne(__message))?;
                 } else {
                     let __message = format!("check succeeded: `(left != right)`{}{}\
                         \n\

--- a/tanu-integration-tests/src/assertion.rs
+++ b/tanu-integration-tests/src/assertion.rs
@@ -1,0 +1,184 @@
+#![allow(clippy::eq_op, clippy::approx_constant)]
+use tanu::{check, check_eq, check_ne, check_str_eq, eyre};
+
+#[tanu::test]
+async fn check_basic_true() -> eyre::Result<()> {
+    check!(true);
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_with_message() -> eyre::Result<()> {
+    check!(1 == 1, "Numbers should be equal");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_expression() -> eyre::Result<()> {
+    let x = 5;
+    let y = 10;
+    check!(x < y);
+    check!(x + y == 15);
+    check!(x != y);
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_eq_integers() -> eyre::Result<()> {
+    check_eq!(42, 42);
+    check_eq!(0, 0);
+    check_eq!(-1, -1);
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_eq_strings() -> eyre::Result<()> {
+    check_eq!("hello", "hello");
+    check_eq!(String::from("world"), "world");
+    check_eq!("", "");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_eq_with_message() -> eyre::Result<()> {
+    check_eq!(100, 100, "Values should be equal");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_eq_vectors() -> eyre::Result<()> {
+    check_eq!(vec![1, 2, 3], vec![1, 2, 3]);
+    check_eq!(Vec::<i32>::new(), Vec::<i32>::new());
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_ne_integers() -> eyre::Result<()> {
+    check_ne!(1, 2);
+    check_ne!(42, 43);
+    check_ne!(0, 1);
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_ne_strings() -> eyre::Result<()> {
+    check_ne!("hello", "world");
+    check_ne!(String::from("foo"), "bar");
+    check_ne!("", "non-empty");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_ne_with_message() -> eyre::Result<()> {
+    check_ne!(5, 10, "Values should be different");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_str_eq_basic() -> eyre::Result<()> {
+    check_str_eq!("hello", "hello");
+    check_str_eq!(String::from("world"), "world");
+    check_str_eq!("", "");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_str_eq_multiline() -> eyre::Result<()> {
+    let text1 = "line1\nline2\nline3";
+    let text2 = "line1\nline2\nline3";
+    check_str_eq!(text1, text2);
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_str_eq_with_message() -> eyre::Result<()> {
+    check_str_eq!("expected", "expected", "String comparison failed");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_str_eq_whitespace() -> eyre::Result<()> {
+    check_str_eq!("  hello  ", "  hello  ");
+    check_str_eq!("\t\ntest\t\n", "\t\ntest\t\n");
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_combined_assertions() -> eyre::Result<()> {
+    let value = 42;
+    let text = "test";
+
+    check!(value > 0);
+    check_eq!(value, 42);
+    check_ne!(value, 0);
+    check_str_eq!(text, "test");
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_option_values() -> eyre::Result<()> {
+    let some_value = Some(42);
+    let none_value: Option<i32> = None;
+
+    check!(some_value.is_some());
+    check!(none_value.is_none());
+    check_eq!(some_value, Some(42));
+    check_ne!(some_value, None);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_result_values() -> eyre::Result<()> {
+    let ok_result: Result<i32, &str> = Ok(42);
+    let err_result: Result<i32, &str> = Err("error");
+
+    check!(ok_result.is_ok());
+    check!(err_result.is_err());
+    check_eq!(ok_result, Ok(42));
+    check_ne!(ok_result, Err("error"));
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_boolean_operations() -> eyre::Result<()> {
+    let a = true;
+    let b = false;
+
+    check!(a && !b);
+    check!(a || b);
+    check!(!(!a && !b));
+    check_eq!(a, true);
+    check_ne!(a, b);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_floating_point() -> eyre::Result<()> {
+    let pi = 3.14159;
+    let e = 2.71828;
+
+    check!(pi > e);
+    check!(pi > 0.0);
+    check_eq!(pi, 3.14159);
+    check_ne!(pi, e);
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn check_json_like_structure() -> eyre::Result<()> {
+    use serde_json::json;
+
+    let json1 = json!({"name": "John", "age": 30});
+    let json2 = json!({"name": "John", "age": 30});
+    let json3 = json!({"name": "Jane", "age": 25});
+
+    check_eq!(json1, json2);
+    check_ne!(json1, json3);
+
+    Ok(())
+}

--- a/tanu-integration-tests/src/main.rs
+++ b/tanu-integration-tests/src/main.rs
@@ -1,3 +1,4 @@
+mod assertion;
 mod http;
 mod macros;
 mod misc;


### PR DESCRIPTION
Update check_ne and check_str_eq macros to use tanu::assertion::Error instead of relative Error import to avoid namespace conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)