### PR TITLE
🐶 Add test summary with count and timing display

### DIFF
--- a/tanu-tui/src/lib.rs
+++ b/tanu-tui/src/lib.rs
@@ -809,6 +809,9 @@ impl Runtime {
                                 // TODO error
                             }
                         },
+                        runner::Event {project: _, module: _, test: _, body: EventBody::Summary(_summary)} => {
+                            // Summary events are handled by the reporters, no TUI action needed
+                        },
 
                     }
                 }


### PR DESCRIPTION
Shows "Tests: X passed, Y failed, Z total" and execution time after test runs complete.

🤖 Generated with [Claude Code](https://claude.ai/code)