### PR TITLE
🐶 Add test prep timing to test summary

### DIFF
--- a/tanu-core/src/reporter.rs
+++ b/tanu-core/src/reporter.rs
@@ -479,6 +479,7 @@ impl Reporter for ListReporter {
             passed_tests,
             failed_tests,
             total_time,
+            test_prep_time,
         } = summary;
 
         self.terminal.write_line("")?;
@@ -493,8 +494,9 @@ impl Reporter for ListReporter {
             total_tests
         ))?;
         self.terminal.write_line(&format!(
-            "Time: {}",
-            style(format!("{total_time:.2?}")).dim()
+            "Time: {} (prep: {})",
+            style(format!("{total_time:.2?}")).dim(),
+            style(format!("{test_prep_time:.2?}")).dim()
         ))?;
 
         Ok(())
@@ -651,6 +653,7 @@ impl Reporter for TableReporter {
             passed_tests,
             failed_tests,
             total_time,
+            test_prep_time,
         } = summary;
 
         write(&self.terminal, "")?;
@@ -669,7 +672,11 @@ impl Reporter for TableReporter {
         )?;
         write(
             &self.terminal,
-            format!("Time: {}", style(format!("{total_time:.2?}")).dim()),
+            format!(
+                "Time: {} (prep: {})",
+                style(format!("{total_time:.2?}")).dim(),
+                style(format!("{test_prep_time:.2?}")).dim()
+            ),
         )?;
 
         Ok(())

--- a/tanu-core/src/runner.rs
+++ b/tanu-core/src/runner.rs
@@ -241,6 +241,7 @@ pub struct TestSummary {
     pub passed_tests: usize,
     pub failed_tests: usize,
     pub total_time: Duration,
+    pub test_prep_time: Duration,
 }
 
 /// Test metadata and identification.
@@ -835,10 +836,11 @@ impl Runner {
                 })
                 .collect()
         };
+        let test_prep_time = start.elapsed();
         debug!(
             "created handles for {} test cases; took {}s",
             handles.len(),
-            start.elapsed().as_secs_f32()
+            test_prep_time.as_secs_f32()
         );
 
         let mut has_any_error = false;
@@ -880,6 +882,7 @@ impl Runner {
                 passed_tests,
                 failed_tests,
                 total_time,
+                test_prep_time,
             };
 
             // Create a dummy event for summary (since it doesn't belong to a specific test)


### PR DESCRIPTION
Added measurement and display of test preparation time (setup phase including semaphore creation, project filtering, and test handle preparation) in the test summary output.

🤖 Generated with [Claude Code](https://claude.ai/code)