### PR TITLE
Add scope_current for spawned Tokio tasks

### DIFF
--- a/tanu-core/src/lib.rs
+++ b/tanu-core/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! This crate provides the fundamental building blocks for tanu, including:
 //! - Test runners and execution logic
-//! - HTTP client functionality  
+//! - HTTP client functionality
 //! - Assertion macros and utilities
 //! - Configuration management
 //! - Test reporting infrastructure

--- a/tanu-integration-tests/src/main.rs
+++ b/tanu-integration-tests/src/main.rs
@@ -3,6 +3,7 @@ mod grpc;
 mod http;
 mod macros;
 mod misc;
+mod task_local;
 
 use std::sync::Arc;
 

--- a/tanu-integration-tests/src/task_local.rs
+++ b/tanu-integration-tests/src/task_local.rs
@@ -1,0 +1,32 @@
+use tanu::{check, eyre};
+
+#[tanu::test]
+async fn spawned_task_without_scope_current_panics() -> eyre::Result<()> {
+    let _ = tanu::get_config();
+
+    let handle = tokio::spawn(async move {
+        let _ = tanu::get_config();
+    });
+
+    let join_err = handle
+        .await
+        .expect_err("spawned task should panic without tanu task-local context");
+    check!(join_err.is_panic());
+
+    Ok(())
+}
+
+#[tanu::test]
+async fn spawned_task_with_scope_current_does_not_panic() -> eyre::Result<()> {
+    let handle = tokio::spawn(tanu::scope_current(async move {
+        let _ = tanu::get_config();
+        check!(true);
+        eyre::Ok(())
+    }));
+
+    handle
+        .await
+        .expect("spawned task should not panic")?;
+
+    Ok(())
+}

--- a/tanu/src/lib.rs
+++ b/tanu/src/lib.rs
@@ -123,14 +123,13 @@ pub use tanu_core::{
     config::{get_config, get_tanu_config, Config, ProjectConfig},
     http,
     reporter::{ListReporter, NullReporter, Reporter, ReporterType, TableReporter},
-    runner::{self, Runner, TestInfo},
+    runner::{self, scope_current, Runner, TestInfo},
     {check, check_eq, check_ne, check_str_eq},
 };
 
 // Type alias for the async test function
-pub type AsyncTestFn = fn() -> std::pin::Pin<
-    Box<dyn std::future::Future<Output = eyre::Result<()>> + Send + 'static>,
->;
+pub type AsyncTestFn =
+    fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = eyre::Result<()>> + Send + 'static>>;
 
 // Define the test registration structure for inventory
 pub struct TestRegistration {


### PR DESCRIPTION
Tokio task-locals used by tanu (project/test context) aren't propagated into spawned tasks.

Add runner::scope_current and re-export it as tanu::scope_current. Add unit + integration tests and document the workaround in Best Practices and FAQ.