### PR TITLE
Handle panic in TUI mode gracefully

### DIFF
--- a/tanu-integration-tests/src/task_local.rs
+++ b/tanu-integration-tests/src/task_local.rs
@@ -24,9 +24,7 @@ async fn spawned_task_with_scope_current_does_not_panic() -> eyre::Result<()> {
         eyre::Ok(())
     }));
 
-    handle
-        .await
-        .expect("spawned task should not panic")?;
+    handle.await.expect("spawned task should not panic")?;
 
     Ok(())
 }

--- a/tanu-integration-tests/tanu.toml
+++ b/tanu-integration-tests/tanu.toml
@@ -1,0 +1,3 @@
+[[projects]]
+name = "default"
+test_ignore = ["tanu_integration_tests::task_local::spawned_task_without_scope_current_panics"]


### PR DESCRIPTION
- Install panic hook that restores terminal before displaying panic info
- Add PANIC_OCCURRED flag to signal event loop to exit on panic
- Reset terminal state on startup in case previous run crashed
- Add tanu.toml to integration tests with test_ignore for panic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)