### PR TITLE
🧪 Add retry integration test

### DIFF
--- a/tanu-integration-tests/src/main.rs
+++ b/tanu-integration-tests/src/main.rs
@@ -3,6 +3,7 @@ mod grpc;
 mod http;
 mod macros;
 mod misc;
+mod retry;
 mod task_local;
 mod tcp;
 

--- a/tanu-integration-tests/src/retry.rs
+++ b/tanu-integration-tests/src/retry.rs
@@ -1,0 +1,24 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tanu::eyre;
+
+/// Counter to track retry attempts across test invocations.
+/// This persists across retry attempts within the same process.
+static RETRY_ATTEMPT: AtomicUsize = AtomicUsize::new(0);
+
+/// Test that fails on the first attempt and succeeds on retry.
+/// This validates that the retry mechanism correctly re-executes failed tests.
+///
+/// Note: Retry only works for error returns, not panics.
+#[tanu::test]
+async fn succeeds_after_retry() -> eyre::Result<()> {
+    let attempt = RETRY_ATTEMPT.fetch_add(1, Ordering::SeqCst);
+
+    if attempt == 0 {
+        // First attempt - fail with an error to trigger retry
+        eyre::bail!("Intentional failure on first attempt");
+    }
+
+    // Subsequent attempts succeed
+    Ok(())
+}

--- a/tanu-integration-tests/tanu.toml
+++ b/tanu-integration-tests/tanu.toml
@@ -1,3 +1,5 @@
 [[projects]]
 name = "default"
 test_ignore = ["tanu_integration_tests::task_local::spawned_task_without_scope_current_panics"]
+retry.count = 3
+retry.min_delay = "100ms"


### PR DESCRIPTION
Add test that fails on first attempt and succeeds on retry to validate the retry mechanism. Enable retry config in integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)