### PR TITLE
🐶 Add worker_id to Test struct for timeline visualization

### DIFF
--- a/tanu-core/src/reporter.rs
+++ b/tanu-core/src/reporter.rs
@@ -452,6 +452,7 @@ impl Reporter for ListReporter {
             request_time,
             started_at: _,
             ended_at: _,
+            worker_id: _,
         } = test;
         let test_number = style(buffer.test_number.get_or_insert_with(generate_test_number)).dim();
         let request_time = style(format!("({request_time:.2?})")).dim();

--- a/tanu-tui/src/widget/list.rs
+++ b/tanu-tui/src/widget/list.rs
@@ -219,6 +219,7 @@ impl ExecutionStateController {
                 module_name: module_state.name.clone(),
                 test: Some(tanu_core::runner::Test {
                     info: Arc::new(TestInfo::default()),
+                    worker_id: 0,
                     result: if ok {
                         Ok(())
                     } else {
@@ -259,6 +260,7 @@ impl ExecutionStateController {
                         module: "".into(),
                         name: "".into(),
                     }),
+                    worker_id: 0,
                     result: if ok {
                         Ok(())
                     } else {
@@ -894,6 +896,7 @@ mod test {
                     module: "".into(),
                     name: "".into(),
                 }),
+                worker_id: 0,
                 result: Ok(()),
                 started_at: SystemTime::UNIX_EPOCH,
                 ended_at: SystemTime::UNIX_EPOCH,
@@ -913,6 +916,7 @@ mod test {
                     module: "".into(),
                     name: "".into(),
                 }),
+                worker_id: 0,
                 result: Err(tanu_core::runner::Error::ErrorReturned("fail".into())),
                 started_at: SystemTime::UNIX_EPOCH,
                 ended_at: SystemTime::UNIX_EPOCH,


### PR DESCRIPTION
Add WorkerIds pool to track which worker slot executed each test. When concurrency is specified via -c flag, tests are assigned reusable worker IDs (0 to concurrency-1). When concurrency is not specified, worker_id is -1.

This enables external tools to visualize test execution timelines with proper lane assignment.