### PR TITLE
🐶 Add runner configuration section to tanu.toml

### DIFF
--- a/docs/command-line-option.md
+++ b/docs/command-line-option.md
@@ -1,18 +1,20 @@
 # Command Line Options
 
+!!! tip
+    Many command-line options can be configured as defaults in `tanu.toml` under the `[runner]` section. See the [Configuration](configuration.md#runner) page for details. Command-line flags always override configuration file settings.
 
 ## `test`
 Run tests with tanu.
 
 ### Options
-* `--capture-http`         Capture http debug logs
-* `--show-sensitive`       Show sensitive data (API keys, tokens) in HTTP logs instead of masking them. By default, sensitive query parameters (api_key, access_token, token, secret, password) and headers (authorization, x-api-key, cookie) are masked with `*****` for security. Use this flag to display actual values during debugging.
-* `--capture-rust`         Capture Rust "log" crate based logs. This is usefull in the following two cases 1) tanu failed unexpectedly and you would want to see the tanu's internal logs. 2) you would want to see logs produced from your tests that uses "log" crate
+* `--capture-http`         Capture http debug logs. Can also be set in `tanu.toml` as `runner.capture_http = true`.
+* `--show-sensitive`       Show sensitive data (API keys, tokens) in HTTP logs instead of masking them. By default, sensitive query parameters (api_key, access_token, token, secret, password) and headers (authorization, x-api-key, cookie) are masked with `*****` for security. Use this flag to display actual values during debugging. Can also be set in `tanu.toml` as `runner.show_sensitive = true`.
+* `--capture-rust`         Capture Rust "log" crate based logs. This is usefull in the following two cases 1) tanu failed unexpectedly and you would want to see the tanu's internal logs. 2) you would want to see logs produced from your tests that uses "log" crate. Can also be set in `tanu.toml` as `runner.capture_rust = true`.
 * `-p, --projects <PROJECTS>`  Run only the specified projects. This option can be specified multiple times e.g. --projects dev --projects staging
 * `-m, --modules <MODULES>`    Run only the specified modules. This option can be specified multiple times e.g. --modules foo --modules bar
 * `-t, --tests <TESTS>`        Run only the specified test cases. This option can be specified multiple times e.g. --tests a ---tests b
 * `--reporter <REPORTER>`  Specify the reporter to use. Default is "table". Possible values are "table", "list" and "null"
-* `-c, --concurrency <NUMBER>` Specify the maximum number of tests to run in parallel. When unspecified, all tests run in parallel.
+* `-c, --concurrency <NUMBER>` Specify the maximum number of tests to run in parallel. When unspecified, all tests run in parallel. Can also be set in `tanu.toml` as `runner.concurrency = 4`.
 * `--color <WHEN>`         Control when colored output is used. Possible values are "auto" (default), "always", or "never". Environment variable `CARGO_TERM_COLOR` is also respected.
 
 ## `tui`
@@ -21,7 +23,7 @@ Launch the TUI (Text User Interface) for tanu.
 ### Options
 * `--log-level <LOG_LEVEL>`            [default: Info]
 * `--tanu-log-level <TANU_LOG_LEVEL>`  [default: Info]
-* `-c, --concurrency <NUMBER>` Specify the maximum number of tests to run in parallel. Default is the number of logical CPU cores
+* `-c, --concurrency <NUMBER>` Specify the maximum number of tests to run in parallel. Default is the number of logical CPU cores. Can also be set in `tanu.toml` as `runner.concurrency = 4`.
 
 ## `ls`
 List test cases.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,8 +16,12 @@ The `tanu.toml` file consists of multiple `[[projects]]` tables, each representi
 Below is an example of a `tanu.toml` file:
 
 ```toml
-[tanu]
-payload.color_theme: "tomorrow-night"  # Replace with your preferred theme name
+[tui]
+payload.color_theme = "tomorrow-night"  # Replace with your preferred theme name
+
+[runner]
+capture_http = true     # Capture HTTP debug logs
+concurrency = 4         # Run up to 4 tests in parallel
 
 [[projects]]
 name = "staging"
@@ -40,6 +44,28 @@ retry.jitter = true
 retry.min_delay = "1s"
 retry.max_delay = "60s"
 ```
+
+## Runner
+
+The `[runner]` section configures global test execution behavior. All values are optional and serve as defaults that can be overridden by command-line flags.
+
+```toml
+[runner]
+capture_http = true      # Capture HTTP debug logs (default: false)
+capture_rust = false     # Capture Rust "log" crate logs (default: false)
+show_sensitive = false   # Show sensitive data in HTTP logs (default: false)
+concurrency = 4          # Max parallel tests (default: unlimited for CLI, CPU cores for TUI)
+```
+
+### Options
+
+- `capture_http`: When enabled, captures and displays HTTP request/response logs for debugging. Default is `false`. Can be overridden with `--capture-http`.
+- `capture_rust`: When enabled, captures logs from Rust's `log` crate. Useful for debugging tanu internals or test code that uses the log crate. Default is `false`. Can be overridden with `--capture-rust`.
+- `show_sensitive`: When enabled, displays sensitive data (API keys, tokens, passwords) in HTTP logs instead of masking them with `*****`. Use with caution as this may expose secrets. Default is `false`. Can be overridden with `--show-sensitive`.
+- `concurrency`: Maximum number of tests to run in parallel. If not specified, CLI mode runs all tests in parallel (unlimited), while TUI mode defaults to the number of CPU cores. Can be overridden with `-c` or `--concurrency`.
+
+!!! note
+    Command-line flags always take precedence over configuration file settings. Use configuration file settings to establish project defaults and command-line flags for one-off overrides.
 
 ## Retry
 
@@ -118,7 +144,7 @@ You can customize the appearance of Tanu's interface by selecting a color theme.
 To change the theme, add the following to your `tanu.toml` configuration file:
 
 ```toml
-[tanu]
+[tui]
 payload.color_theme = "tomorrow-night"  # Replace with your preferred theme name
 ```
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -167,7 +167,12 @@ cargo run test -t pattern  # Run tests matching pattern
 ```
 
 ### Can I run tests in parallel?
-Yes, tanu runs tests concurrently by default. You can control concurrency with command-line options.
+Yes, tanu runs tests concurrently by default. You can control concurrency using:
+
+- Command-line flag: `--concurrency 4` or `-c 4`
+- Configuration file: `runner.concurrency = 4` in `tanu.toml`
+
+See the [Runner Configuration](configuration.md#runner) section for more details.
 
 ### How do I use the TUI mode?
 ```bash
@@ -216,7 +221,19 @@ This might be due to:
 - Resource cleanup issues
 
 ### How do I debug HTTP requests?
-Tanu automatically captures HTTP request/response logs. Use the TUI mode to inspect detailed request information.
+Use the `--capture-http` flag to capture HTTP request/response logs:
+
+```bash
+cargo run -- test --capture-http
+```
+
+You can also enable this by default in `tanu.toml`:
+```toml
+[runner]
+capture_http = true
+```
+
+For interactive debugging, use TUI mode to inspect detailed request information. See [Best Practices - HTTP Debugging](best-practices.md#http-debugging) for more details on automatic sensitive data masking.
 
 ## Performance
 
@@ -225,9 +242,9 @@ Tanu is built in Rust and leverages zero-cost abstractions for minimal overhead.
 
 ### Can I control test execution speed?
 Yes, through configuration:
-- Adjust concurrency levels
-- Configure timeouts
-- Use retry settings appropriately
+- Adjust concurrency levels with `--concurrency` flag or `runner.concurrency` in config
+- Configure timeouts in your HTTP client
+- Use retry settings appropriately (see [Retry Configuration](configuration.md#retry))
 - Consider rate limiting for API protection
 
 ## Integration

--- a/tanu-sample.toml
+++ b/tanu-sample.toml
@@ -1,6 +1,12 @@
 [tui]
 payload.color_theme = "apathy"  # color theme for the payload tab, default is "solarized-dark"
 
+[runner]
+# capture_http = true     # capture HTTP debug logs, default is false
+# capture_rust = true     # capture Rust "log" crate logs, default is false
+# show_sensitive = true   # show sensitive data in HTTP logs instead of masking, default is false
+# concurrency = 4         # max parallel tests, default is unlimited (test mode) or CPU cores (tui mode)
+
 [[projects]]
 name = "default"        # project name
 test_ignore = []        # list of test names to exclude


### PR DESCRIPTION
Adds [runner] section to tanu.toml for configuring test execution defaults:
- capture_http: Capture HTTP debug logs
- capture_rust: Capture Rust log crate logs
- show_sensitive: Show sensitive data in HTTP logs
- concurrency: Max parallel tests

CLI flags override config values. Updated documentation with examples and cross-references.