### PR TITLE
Add rustls TLS backend feature flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,18 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy, rustfmt
-    - name: build crates and examples
+    - name: build crates and examples (native-tls)
       run: |
-        cargo build --workspace --all-targets --all-features
-    - name: run clippy
+        cargo build --workspace --all-targets --features "json,multipart,cookies,grpc,graphql,native-tls"
+    - name: build crates and examples (rustls-tls)
       run: |
-        cargo clippy --workspace --all-targets --all-features -- --deny clippy::all
+        cargo build --workspace --all-targets --no-default-features --features "json,multipart,cookies,grpc,graphql,rustls-tls-webpki-roots"
+    - name: run clippy (native-tls)
+      run: |
+        cargo clippy --workspace --all-targets --features "json,multipart,cookies,grpc,graphql,native-tls" -- --deny clippy::all
+    - name: run clippy (rustls-tls)
+      run: |
+        cargo clippy --workspace --all-targets --no-default-features --features "json,multipart,cookies,grpc,graphql,rustls-tls-webpki-roots" -- --deny clippy::all
     - name: install nextest
       uses: taiki-e/install-action@nextest
     - name: run unit tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,14 +29,17 @@ Tanu is an async-friendly WebAPI testing framework for Rust with CLI and TUI mod
 - `cargo build --workspace` builds all crates in the workspace.
 - `cargo test --workspace` runs Rust unit tests across crates.
 - `cargo fmt --all` formats Rust code using rustfmt defaults.
-- `cargo clippy --workspace --all-targets --all-features` runs lint checks.
-- `cargo build --workspace --all-targets --all-features` builds all targets with full feature coverage.
+- `cargo clippy --workspace --all-targets --features "json,multipart,cookies,grpc,graphql,native-tls"` runs lint checks (native-tls).
+- `cargo clippy --workspace --all-targets --no-default-features --features "json,multipart,cookies,grpc,graphql,rustls-tls-webpki-roots"` runs lint checks (rustls-tls).
+- `cargo build --workspace --all-targets --features "json,multipart,cookies,grpc,graphql,native-tls"` builds all targets with full feature coverage (native-tls).
+- `cargo build --workspace --all-targets --no-default-features --features "json,multipart,cookies,grpc,graphql,rustls-tls-webpki-roots"` builds all targets with full feature coverage (rustls-tls).
+- Note: `--all-features` cannot be used because `native-tls` and `rustls-tls` are mutually exclusive.
 - `cargo run -p tanu-integration-tests -- test` runs the integration suite with the tanu runner (requires Docker for the httpbin container).
 
 ## Required Post-Change Workflow
 After every code change, always run these three commands in order:
 1. `cargo fmt --all`
-2. `cargo clippy --workspace --all-targets --all-features`
+2. `cargo clippy --workspace --all-targets --features "json,multipart,cookies,grpc,graphql,native-tls"`
 3. `TANU_CONFIG=./tanu-integration-tests/tanu.toml cargo run -p tanu-integration-tests -- test`
 - `cargo run -p tanu-integration-tests -- tui` launches the interactive TUI test runner.
 - `cargo run -p tanu-integration-tests -- ls` lists all available test cases.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ pretty_assertions = "1"
 hyper = { version = "1.8", features = ["full"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
 hyper-tls = "0.6"
+hyper-rustls = { version = "0.27", features = ["http1", "http2"] }
+rustls = "0.23"
+webpki-roots = "0.26"
+rustls-native-certs = "0.8"
 http-body = "1"
 http-body-util = "0.1"
 bytes = "1"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["native-tls"]
+native-tls = ["tanu/native-tls"]
+rustls-tls = ["tanu/rustls-tls"]
+rustls-tls-webpki-roots = ["tanu/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu/rustls-tls-native-roots"]
 grpc = ["tanu/grpc", "tonic"]
 
 [dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ grpc = ["tanu/grpc", "tonic"]
 
 [dependencies]
 serde = { workspace = true }
-tanu = { path = "../tanu" }
+tanu = { path = "../tanu", default-features = false }
 tokio = { workspace = true }
 tonic = { workspace = true, optional = true }
 url = { version = "2", features = ["serde"] }

--- a/tanu-core/Cargo.toml
+++ b/tanu-core/Cargo.toml
@@ -28,7 +28,13 @@ once_cell = { workspace = true }
 pretty_assertions = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
-hyper-tls = { workspace = true }
+hyper-tls = { workspace = true, optional = true }
+
+# rustls support (optional)
+hyper-rustls = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
+webpki-roots = { workspace = true, optional = true }
+rustls-native-certs = { workspace = true, optional = true }
 http-body-util = { workspace = true }
 bytes = { workspace = true }
 base64 = "0.22"
@@ -62,7 +68,11 @@ serial_test = "3"
 test-case = { workspace = true }
 
 [features]
-default = []
+default = ["native-tls"]
+native-tls = ["hyper-tls"]
+rustls-tls = ["hyper-rustls", "rustls"]
+rustls-tls-webpki-roots = ["rustls-tls", "webpki-roots"]
+rustls-tls-native-roots = ["rustls-tls", "rustls-native-certs"]
 json = []
 multipart = []
 cookies = ["cookie"]

--- a/tanu-core/src/http.rs
+++ b/tanu-core/src/http.rs
@@ -70,6 +70,15 @@ use tracing::*;
 
 use crate::masking;
 
+// Ensure exactly one TLS backend is selected
+#[cfg(all(feature = "native-tls", feature = "rustls-tls"))]
+compile_error!(
+    "Features `native-tls` and `rustls-tls` are mutually exclusive. Please enable only one."
+);
+
+#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+compile_error!("Either feature `native-tls` or `rustls-tls` must be enabled for TLS support.");
+
 #[cfg(feature = "cookies")]
 use std::collections::HashMap;
 
@@ -126,8 +135,12 @@ pub enum Error {
     Uri(#[from] http::uri::InvalidUri),
     #[error("HeaderError: {0}")]
     Header(#[from] http::Error),
+    #[cfg(feature = "native-tls")]
     #[error("TlsError: {0}")]
     Tls(#[from] hyper_tls::native_tls::Error),
+    #[cfg(feature = "rustls-tls")]
+    #[error("TlsError: {0}")]
+    Tls(#[from] rustls::Error),
     #[error("Request timed out after {0:?}")]
     Timeout(Duration),
     #[error("failed to deserialize http response into the specified type: {0}")]
@@ -388,8 +401,14 @@ impl Response {
 /// ```
 #[derive(Clone)]
 pub struct Client {
+    #[cfg(feature = "native-tls")]
     pub(crate) inner: HyperClient<
         hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+        Full<Bytes>,
+    >,
+    #[cfg(feature = "rustls-tls")]
+    pub(crate) inner: HyperClient<
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
         Full<Bytes>,
     >,
     #[cfg(feature = "cookies")]
@@ -418,8 +437,42 @@ impl Client {
     /// let client = Client::new();
     /// ```
     pub fn new() -> Client {
-        let https = hyper_tls::HttpsConnector::new();
-        let inner = HyperClient::builder(TokioExecutor::new()).build::<_, Full<Bytes>>(https);
+        #[cfg(feature = "native-tls")]
+        let inner = {
+            let https = hyper_tls::HttpsConnector::new();
+            HyperClient::builder(TokioExecutor::new()).build::<_, Full<Bytes>>(https)
+        };
+
+        #[cfg(feature = "rustls-tls")]
+        let inner = {
+            let mut root_store = rustls::RootCertStore::empty();
+
+            #[cfg(feature = "rustls-tls-native-roots")]
+            {
+                let native_certs = rustls_native_certs::load_native_certs();
+                for cert in native_certs {
+                    root_store.add(cert).ok();
+                }
+            }
+
+            #[cfg(feature = "rustls-tls-webpki-roots")]
+            {
+                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            }
+
+            let tls_config = rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+
+            let https = hyper_rustls::HttpsConnectorBuilder::new()
+                .with_tls_config(tls_config)
+                .https_or_http()
+                .enable_http1()
+                .enable_http2()
+                .build();
+
+            HyperClient::builder(TokioExecutor::new()).build::<_, Full<Bytes>>(https)
+        };
 
         Client {
             inner,

--- a/tanu-integration-tests/Cargo.toml
+++ b/tanu-integration-tests/Cargo.toml
@@ -24,7 +24,7 @@ dtor = "0.0.6"
 prost = "0.14.1"
 serde = { workspace = true }
 serde_json = "1"
-tanu = { path = "../tanu", features = ["json", "cookies", "grpc", "graphql"] }
+tanu = { path = "../tanu", default-features = false, features = ["json", "cookies", "grpc", "graphql"] }
 testcontainers = "0.24"
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/tanu-integration-tests/Cargo.toml
+++ b/tanu-integration-tests/Cargo.toml
@@ -14,6 +14,11 @@ name = "third-runner"
 path = "src/bin/third_runner.rs"
 
 [features]
+default = ["native-tls"]
+native-tls = ["tanu/native-tls"]
+rustls-tls = ["tanu/rustls-tls"]
+rustls-tls-webpki-roots = ["tanu/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu/rustls-tls-native-roots"]
 fail-test = []
 
 [dependencies]

--- a/tanu-tui/Cargo.toml
+++ b/tanu-tui/Cargo.toml
@@ -27,7 +27,7 @@ ratatui = "0.30"
 serde_json = "1"
 strum = { workspace = true }
 syntect = "5"
-tanu-core = { version = "=0.19.0", path = "../tanu-core" }
+tanu-core = { version = "=0.19.0", path = "../tanu-core", default-features = false }
 textwrap = "0.16"
 throbber-widgets-tui = "0.10"
 tokio = { workspace = true }

--- a/tanu/Cargo.toml
+++ b/tanu/Cargo.toml
@@ -27,7 +27,7 @@ pretty_assertions = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
 strum = { workspace = true }
-tanu-core = { version = "=0.19.0", path = "../tanu-core" }
+tanu-core = { version = "=0.19.0", path = "../tanu-core", default-features = false }
 tanu-derive = { version = "=0.19.0", path = "../tanu-derive" }
 tanu-tui = { version = "=0.19.0", path = "../tanu-tui" }
 thiserror = "1"
@@ -37,7 +37,11 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [features]
-default = []
+default = ["native-tls"]
+native-tls = ["tanu-core/native-tls"]
+rustls-tls = ["tanu-core/rustls-tls"]
+rustls-tls-webpki-roots = ["tanu-core/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu-core/rustls-tls-native-roots"]
 json = ["tanu-core/json"]
 multipart = ["tanu-core/multipart"]
 cookies = ["tanu-core/cookies"]


### PR DESCRIPTION
This pull request introduces support for both `native-tls` and `rustls` TLS backends in the project, making TLS support more flexible and configurable. It also adds Nix-based development environment files for easier onboarding and consistent tooling, and updates documentation and CI workflows to reflect the new feature flags and build matrix.

TLS backend support and configuration:

* Added optional dependencies for `hyper-rustls`, `rustls`, `webpki-roots`, and `rustls-native-certs` in `Cargo.toml`, and defined new features: `native-tls` (default), `rustls-tls`, `rustls-tls-webpki-roots`, and `rustls-tls-native-roots` for flexible TLS backend selection. (`tanu-core/Cargo.toml`, `tanu/Cargo.toml`, [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R28-R31) [[2]](diffhunk://#diff-c4b88783a9206e0aef9d4249369ff8f71c70dd2205d4878cd80914226a12fffeL31-R37) [[3]](diffhunk://#diff-c4b88783a9206e0aef9d4249369ff8f71c70dd2205d4878cd80914226a12fffeL65-R75) [[4]](diffhunk://#diff-8c47e43626bbbfd11ef07b6d2142c59ee5ab2e8e49e85a85ad4a83b5e3d600c3L40-R44)
* Updated the `Client` implementation in `tanu-core/src/http.rs` to initialize the appropriate TLS connector based on the enabled feature, and to ensure that exactly one backend is enabled at build time. (`tanu-core/src/http.rs`, [[1]](diffhunk://#diff-76d28a2e5dc9c6346932b91ae8f5ac95d656ac4c7501a70dfc5c14c91bd1a46aR73-R81) [[2]](diffhunk://#diff-76d28a2e5dc9c6346932b91ae8f5ac95d656ac4c7501a70dfc5c14c91bd1a46aR138-R143) [[3]](diffhunk://#diff-76d28a2e5dc9c6346932b91ae8f5ac95d656ac4c7501a70dfc5c14c91bd1a46aR404-R413) [[4]](diffhunk://#diff-76d28a2e5dc9c6346932b91ae8f5ac95d656ac4c7501a70dfc5c14c91bd1a46aR440-R475)

CI and documentation updates:

* Updated the GitHub Actions workflow to build and lint the project with both `native-tls` and `rustls-tls` feature sets, ensuring both configurations are tested in CI. (`.github/workflows/test.yml`, [.github/workflows/test.ymlL25-R36](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L25-R36))
* Revised documentation in `CLAUDE.md` to explain the mutually exclusive nature of TLS features and to provide updated build and lint commands for each backend. (`CLAUDE.md`, [CLAUDE.mdL32-R42](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L32-R42))