### PR TITLE
Add default TLS feature to internal crates for standalone builds

### DIFF
--- a/tanu-tui/Cargo.toml
+++ b/tanu-tui/Cargo.toml
@@ -46,5 +46,9 @@ pretty_assertions = { workspace = true }
 eyre = { workspace = true }
 
 [features]
-default = []
+default = ["native-tls"]
+native-tls = ["tanu-core/native-tls"]
+rustls-tls = ["tanu-core/rustls-tls"]
+rustls-tls-webpki-roots = ["tanu-core/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu-core/rustls-tls-native-roots"]
 grpc = ["tanu-core/grpc", "tonic"]

--- a/tanu/Cargo.toml
+++ b/tanu/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1"
 strum = { workspace = true }
 tanu-core = { version = "=0.20.0", path = "../tanu-core", default-features = false }
 tanu-derive = { version = "=0.20.0", path = "../tanu-derive" }
-tanu-tui = { version = "=0.20.0", path = "../tanu-tui" }
+tanu-tui = { version = "=0.20.0", path = "../tanu-tui", default-features = false }
 thiserror = "1"
 tokio = { workspace = true }
 toml = "0.8"
@@ -38,10 +38,10 @@ tracing-subscriber = { workspace = true }
 
 [features]
 default = ["native-tls"]
-native-tls = ["tanu-core/native-tls"]
-rustls-tls = ["tanu-core/rustls-tls"]
-rustls-tls-webpki-roots = ["tanu-core/rustls-tls-webpki-roots"]
-rustls-tls-native-roots = ["tanu-core/rustls-tls-native-roots"]
+native-tls = ["tanu-core/native-tls", "tanu-tui/native-tls"]
+rustls-tls = ["tanu-core/rustls-tls", "tanu-tui/rustls-tls"]
+rustls-tls-webpki-roots = ["tanu-core/rustls-tls-webpki-roots", "tanu-tui/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["tanu-core/rustls-tls-native-roots", "tanu-tui/rustls-tls-native-roots"]
 json = ["tanu-core/json"]
 multipart = ["tanu-core/multipart"]
 cookies = ["tanu-core/cookies"]


### PR DESCRIPTION
This pull request updates the TLS feature configuration for both the `tanu` and `tanu-tui` crates to ensure more consistent and explicit control over TLS backend selection. The changes clarify how TLS features are enabled and propagated between crates, and make the default features more explicit.

Dependency and feature configuration updates:

* In `tanu-tui/Cargo.toml`, the `default` feature now enables `native-tls`, and new features for various TLS backends (`native-tls`, `rustls-tls`, `rustls-tls-webpki-roots`, `rustls-tls-native-roots`) are added, each forwarding to the corresponding feature in `tanu-core`.
* In `tanu/Cargo.toml`, the dependency on `tanu-tui` now explicitly disables default features, which allows `tanu` to control which TLS backend is enabled.
* The TLS-related features in `tanu/Cargo.toml` are updated to forward the selected TLS backend features to both `tanu-core` and `tanu-tui`, ensuring that both crates use the same TLS backend when a feature is enabled.