### PR TITLE
🐛 Fix rustls-native-certs 0.8 API usage

### DIFF
--- a/tanu-core/src/http.rs
+++ b/tanu-core/src/http.rs
@@ -450,7 +450,7 @@ impl Client {
             #[cfg(feature = "rustls-tls-native-roots")]
             {
                 let native_certs = rustls_native_certs::load_native_certs();
-                for cert in native_certs {
+                for cert in native_certs.certs {
                     root_store.add(cert).ok();
                 }
             }

--- a/tanu-core/src/runner.rs
+++ b/tanu-core/src/runner.rs
@@ -1093,7 +1093,7 @@ impl Runner {
             let mut all_tests: Vec<_> = self
                 .test_cases
                 .iter()
-                .cartesian_product(projects.into_iter())
+                .cartesian_product(projects)
                 .map(|((info, factory), project)| (project, Arc::clone(info), factory.clone()))
                 .filter(move |(project, info, _)| test_name_filter.filter(project, info))
                 .filter(move |(project, info, _)| module_filter.filter(project, info))

--- a/tanu-derive/src/lib.rs
+++ b/tanu-derive/src/lib.rs
@@ -310,10 +310,8 @@ fn extract_and_stringify_option(expr: &Expr) -> Option<String> {
                 }
             }
         }
-        Expr::Path(ExprPath { path, .. }) => {
-            if path.get_ident()? == "None" {
-                return Some("None".into());
-            }
+        Expr::Path(ExprPath { path, .. }) if path.get_ident()? == "None" => {
+            return Some("None".into());
         }
         _ => {}
     }


### PR DESCRIPTION
This pull request makes a minor fix to the way native certificates are loaded when the `rustls-tls-native-roots` feature is enabled. The code now iterates over `native_certs.certs` instead of `native_certs`, ensuring the correct collection of certificates is used.

* Fixed iteration to use the `certs` field of `native_certs` when adding certificates to the `root_store` in `tanu-core/src/http.rs`.