### PR TITLE
🧹 Remove TableReporter and tabled dependency

### DIFF
--- a/tanu-core/Cargo.toml
+++ b/tanu-core/Cargo.toml
@@ -45,7 +45,6 @@ zstd = "0.13"
 serde = { workspace = true }
 serde_json = "1"
 strum = { workspace = true }
-tabled = "0.18"
 tanu-derive = { version = "=0.20.2", path = "../tanu-derive" }
 thiserror = "2"
 tokio = { workspace = true }

--- a/tanu-core/src/reporter.rs
+++ b/tanu-core/src/reporter.rs
@@ -9,7 +9,6 @@
 //!
 //! - **`NullReporter`**: No output (useful for testing)
 //! - **`ListReporter`**: Real-time streaming output with detailed logs
-//! - **`TableReporter`**: Summary table output after all tests complete
 //!
 //! ## Custom Reporters
 //!
@@ -36,18 +35,13 @@
 //! ```
 
 use console::{style, StyledObject, Term};
-use eyre::WrapErr;
 use indexmap::IndexMap;
-use itertools::Itertools;
-use std::{
-    collections::HashMap,
-    sync::{LazyLock, Mutex},
-};
+use std::sync::{LazyLock, Mutex};
 use tokio::sync::broadcast;
 use tracing::*;
 
 use crate::{
-    get_tanu_config, http,
+    http,
     runner::{self, Event, EventBody, Test},
     CaptureHttpMode, ModuleName, ProjectName, TestName,
 };
@@ -61,14 +55,12 @@ use crate::{
 ///
 /// - `Null`: No output, useful for testing or when output is not needed
 /// - `List`: Real-time streaming output with detailed information
-/// - `Table`: Summary table displayed after all tests complete
 #[derive(Debug, Clone, Default, strum::EnumString, strum::Display)]
 #[strum(serialize_all = "snake_case")]
 pub enum ReporterType {
     Null,
     #[default]
     List,
-    Table,
 }
 
 async fn run<R: Reporter + Send + ?Sized>(reporter: &mut R) -> eyre::Result<()> {
@@ -552,11 +544,6 @@ impl Reporter for ListReporter {
     }
 }
 
-fn write(term: &Term, s: impl AsRef<str>) -> eyre::Result<()> {
-    let colored = style(s.as_ref()).dim();
-    term.write_line(&format!("{colored}"))
-        .wrap_err("failed to write character on terminal")
-}
 
 fn symbol_test_result(test: &Test) -> StyledObject<&'static str> {
     match test.result {
@@ -573,12 +560,6 @@ fn symbol_error() -> StyledObject<&'static str> {
     style("✘").red()
 }
 
-fn emoji_symbol_test_result(test: &Test) -> char {
-    match test.result {
-        Ok(_) => '🟢',
-        Err(_) => '🔴',
-    }
-}
 
 /// Color HTTP methods for visual distinction
 fn style_http_method(method: &str) -> StyledObject<&str> {
@@ -642,6 +623,7 @@ fn style_project(name: &str) -> StyledObject<String> {
 fn style_module_path(module: &str, test: &str) -> String {
     format!("{}::{}", style(module).cyan(), style(test).blue().bold())
 }
+
 
 fn write_http_log(terminal: &Term, log: &http::Log) -> eyre::Result<()> {
     terminal.write_line(&format!(
@@ -791,169 +773,4 @@ fn write_grpc_log(terminal: &Term, log: &crate::grpc::Log) -> eyre::Result<()> {
         ))?;
     }
     Ok(())
-}
-
-#[allow(clippy::vec_box, dead_code)]
-/// A reporter that displays test results in a summary table after all tests complete.
-///
-/// This reporter buffers all test results and displays them in a formatted table
-/// at the end of execution. Useful for getting an overview of all test results
-/// without the noise of real-time output.
-///
-/// # Features
-///
-/// - **Summary table**: Clean tabular output after test completion
-/// - **Project ordering**: Results ordered by project configuration
-/// - **Emoji indicators**: Visual success/failure indicators
-/// - **Modern styling**: Attractive table borders and formatting
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use tanu_core::{Runner, reporter::TableReporter};
-///
-/// let mut runner = Runner::new();
-/// runner.add_reporter(TableReporter::new(false)); // No HTTP details in table
-/// ```
-///
-/// # Output Format
-///
-/// ```text
-/// ┌─────────┬────────┬──────────────┬────────┐
-/// │ Project │ Module │ Test         │ Result │
-/// ├─────────┼────────┼──────────────┼────────┤
-/// │ staging │ api    │ health_check │   🟢   │
-/// │ staging │ auth   │ login        │   🔴   │
-/// │ prod    │ api    │ status       │   🟢   │
-/// └─────────┴────────┴──────────────┴────────┘
-/// ```
-pub struct TableReporter {
-    terminal: Term,
-    buffer: HashMap<(ProjectName, ModuleName, TestName), Test>,
-    capture_http: CaptureHttpMode,
-}
-
-impl TableReporter {
-    /// Creates a new table reporter.
-    ///
-    /// # Parameters
-    ///
-    /// - `capture_http`: Controls when HTTP details are captured (currently unused in table output)
-    ///
-    /// # Examples
-    ///
-    /// ```rust,ignore
-    /// use tanu_core::{reporter::TableReporter, CaptureHttpMode};
-    ///
-    /// let reporter = TableReporter::new(CaptureHttpMode::Off);
-    /// ```
-    pub fn new(capture_http: CaptureHttpMode) -> TableReporter {
-        TableReporter {
-            terminal: Term::stdout(),
-            buffer: HashMap::new(),
-            capture_http,
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl Reporter for TableReporter {
-    async fn run(&mut self) -> eyre::Result<()> {
-        run(self).await?;
-
-        let project_order: Vec<_> = get_tanu_config().projects.iter().map(|p| &p.name).collect();
-
-        let mut builder = tabled::builder::Builder::default();
-        builder.push_record(["Project", "Module", "Test", "Result"]);
-        self.buffer
-            .drain()
-            .sorted_by(|(a, _), (b, _)| {
-                let project_order_a = project_order
-                    .iter()
-                    .position(|&p| *p == a.0)
-                    .unwrap_or(usize::MAX);
-                let project_order_b = project_order
-                    .iter()
-                    .position(|&p| *p == b.0)
-                    .unwrap_or(usize::MAX);
-
-                project_order_a
-                    .cmp(&project_order_b)
-                    .then(a.1.cmp(&b.1))
-                    .then(a.2.cmp(&b.2))
-            })
-            .for_each(|((p, m, t), test)| {
-                builder.push_record([p, m, t, emoji_symbol_test_result(&test).to_string()])
-            });
-
-        let mut table = builder.build();
-        table.with(tabled::settings::Style::modern()).with(
-            tabled::settings::Modify::new(tabled::settings::object::Columns::single(3))
-                .with(tabled::settings::Alignment::center()),
-        );
-
-        write(&self.terminal, format!("{table}")).wrap_err("failed to write table on terminal")?;
-
-        Ok(())
-    }
-
-    async fn on_end(
-        &mut self,
-        project_name: String,
-        module_name: String,
-        test_name: String,
-        test: Test,
-    ) -> eyre::Result<()> {
-        self.buffer
-            .insert((project_name, module_name, test_name), test);
-        Ok(())
-    }
-
-    async fn on_summary(&mut self, summary: runner::TestSummary) -> eyre::Result<()> {
-        let runner::TestSummary {
-            total_tests,
-            passed_tests,
-            failed_tests,
-            skipped_tests,
-            total_time,
-            test_prep_time,
-        } = summary;
-
-        self.terminal.write_line("")?;
-        let mut summary_line = format!(
-            "{}: {} {}, {} {}, {} {}",
-            style("Tests").bold(),
-            style(passed_tests).green().bold(),
-            style("passed").green(),
-            if failed_tests > 0 {
-                style(failed_tests).red().bold()
-            } else {
-                style(failed_tests).bold()
-            },
-            if failed_tests > 0 {
-                style("failed").red()
-            } else {
-                style("failed")
-            },
-            style(total_tests).bold(),
-            style("total").dim()
-        );
-        if skipped_tests > 0 {
-            summary_line.push_str(&format!(
-                ", {} {}",
-                style(skipped_tests).yellow().bold(),
-                style("skipped").yellow()
-            ));
-        }
-        self.terminal.write_line(&summary_line)?;
-        self.terminal.write_line(&format!(
-            "{}: {} ({}: {})",
-            style("Time").bold(),
-            style(format!("{total_time:.2?}")).cyan(),
-            style("prep").dim(),
-            style(format!("{test_prep_time:.2?}")).dim()
-        ))?;
-
-        Ok(())
-    }
 }

--- a/tanu-core/src/runner.rs
+++ b/tanu-core/src/runner.rs
@@ -775,12 +775,12 @@ impl Filter for TestIgnoreFilter {
 /// # Examples
 ///
 /// ```rust,ignore
-/// use tanu_core::{Runner, reporter::TableReporter};
+/// use tanu_core::{Runner, reporter::ListReporter};
 ///
 /// let mut runner = Runner::new();
 /// runner.capture_http();
 /// runner.set_concurrency(8);
-/// runner.add_reporter(TableReporter::new());
+/// runner.add_reporter(ListReporter::new(false));
 ///
 /// // Add tests (typically done by procedural macros)
 /// runner.add_test("health_check", "api", None, test_factory);
@@ -906,10 +906,10 @@ impl Runner {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// use tanu_core::{Runner, reporter::TableReporter};
+    /// use tanu_core::{Runner, reporter::ListReporter};
     ///
     /// let mut runner = Runner::new();
-    /// runner.add_reporter(TableReporter::new());
+    /// runner.add_reporter(ListReporter::new(false));
     /// ```
     pub fn add_reporter(&mut self, reporter: impl Reporter + 'static + Send) {
         self.reporters.push(Box::new(reporter));

--- a/tanu/src/app.rs
+++ b/tanu/src/app.rs
@@ -12,7 +12,7 @@ use std::{
 use tanu_core::CaptureHttpMode;
 use tanu_core::Filter;
 
-use crate::{get_tanu_config, ListReporter, ReporterType, TableReporter};
+use crate::{get_tanu_config, ListReporter, ReporterType};
 
 /// Define CLI color styles
 fn cli_styles() -> Styles {
@@ -29,7 +29,6 @@ fn cli_styles() -> Styles {
 /// Build the CLI with clap's builder pattern
 fn build_cli<'a>(third_party_reporters: impl Iterator<Item = &'a String>) -> ClapCommand {
     let mut reporter_choices: VecDeque<_> = third_party_reporters.map(|s| s.to_string()).collect();
-    reporter_choices.push_front(ReporterType::Table.to_string());
     reporter_choices.push_front(ReporterType::List.to_string());
     ClapCommand::new("tanu")
         .styles(cli_styles())
@@ -312,20 +311,13 @@ impl App {
                 runner.terminate_channel();
 
                 let mut reporters = std::mem::take(&mut self.third_party_reporters);
-                reporters.extend([
-                    (
-                        ReporterType::Table.to_string(),
-                        Box::new(TableReporter::new(capture_http.clone())),
-                    ),
-                    (
-                        ReporterType::List.to_string(),
-                        Box::new(ListReporter::new(capture_http)),
-                    ),
-                ]
-                    as [(
-                        String,
-                        Box<dyn tanu_core::reporter::Reporter + 'static + Send>,
-                    ); 2]);
+                reporters.extend([(
+                    ReporterType::List.to_string(),
+                    Box::new(ListReporter::new(capture_http)),
+                )] as [(
+                    String,
+                    Box<dyn tanu_core::reporter::Reporter + 'static + Send>,
+                ); 1]);
 
                 for reporter in reporters_arg {
                     runner.add_boxed_reporter(

--- a/tanu/src/lib.rs
+++ b/tanu/src/lib.rs
@@ -123,7 +123,7 @@ pub use tanu_core::{
     assertion,
     config::{get_config, get_tanu_config, CaptureHttpMode, Config, ProjectConfig},
     http, reporter,
-    reporter::{ListReporter, NullReporter, Reporter, ReporterType, TableReporter},
+    reporter::{ListReporter, NullReporter, Reporter, ReporterType},
     runner::{self, scope_current, Runner, TestInfo},
     {check, check_eq, check_ne, check_str_eq},
 };


### PR DESCRIPTION
Drop TableReporter entirely — ListReporter covers all practical use cases. Removes the tabled crate, associated dead helpers (write, emoji_symbol_test_result), and cleans up now-unused imports (itertools, HashMap, WrapErr, get_tanu_config).