### PR TITLE
🐶 Show request body in --capture-http output

### DIFF
--- a/tanu-core/src/http.rs
+++ b/tanu-core/src/http.rs
@@ -154,6 +154,9 @@ pub struct LogRequest {
     pub url: url::Url,
     pub method: Method,
     pub headers: header::HeaderMap,
+    /// Captured request body, if any. Sensitive field values are masked when
+    /// masking is enabled. `None` means no body was sent.
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -718,6 +721,17 @@ impl RequestBuilder {
             } else {
                 self.headers.clone()
             },
+            body: self.body.as_ref().map(|b| {
+                let content_type = self
+                    .headers
+                    .get(header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok());
+                if masking::should_mask_sensitive() {
+                    masking::mask_body(b, content_type)
+                } else {
+                    String::from_utf8_lossy(b).into_owned()
+                }
+            }),
         };
 
         let started_at = SystemTime::now();

--- a/tanu-core/src/masking.rs
+++ b/tanu-core/src/masking.rs
@@ -40,6 +40,12 @@ const SENSITIVE_QUERY_PARAMS: &[&str] = &[
 /// Header names to mask (case-insensitive comparison).
 const SENSITIVE_HEADERS: &[&str] = &["authorization", "x-api-key", "x-auth-token", "cookie"];
 
+/// Returns true if the given key (field/query-param name) is sensitive.
+fn is_sensitive_key(key: &str) -> bool {
+    let key_lower = key.to_lowercase();
+    SENSITIVE_QUERY_PARAMS.iter().any(|&p| key_lower == p)
+}
+
 /// Masks sensitive query parameters in a URL.
 ///
 /// # Examples
@@ -67,8 +73,7 @@ pub fn mask_url(url: &Url) -> Url {
         .map(|pair| {
             // Split on first '=' only to preserve encoded '=' in values
             if let Some((key, _value)) = pair.split_once('=') {
-                let key_lower = key.to_lowercase();
-                if SENSITIVE_QUERY_PARAMS.iter().any(|&p| key_lower == p) {
+                if is_sensitive_key(key) {
                     format!("{key}={MASK}")
                 } else {
                     pair.to_string()
@@ -115,6 +120,82 @@ pub fn mask_headers(headers: &HeaderMap) -> HeaderMap {
     }
 
     masked
+}
+
+/// Masks sensitive field values in an HTTP request body.
+///
+/// Behavior depends on the content-type:
+/// - `application/json*`: parses as JSON and recursively redacts values whose
+///   keys match the sensitive-key list. Falls back to raw UTF-8 on parse failure.
+/// - `application/x-www-form-urlencoded`: masks values for sensitive keys.
+/// - Everything else: returned verbatim as lossy UTF-8.
+///
+/// # Examples
+///
+/// ```
+/// use tanu_core::masking::mask_body;
+///
+/// let body = br#"{"username":"alice","password":"hunter2"}"#;
+/// let masked = mask_body(body, Some("application/json"));
+/// assert!(masked.contains("\"password\":\"*****\""));
+/// assert!(masked.contains("\"username\":\"alice\""));
+/// ```
+pub fn mask_body(body: &[u8], content_type: Option<&str>) -> String {
+    let ct = content_type.unwrap_or("").to_lowercase();
+
+    if ct.starts_with("application/json") {
+        match serde_json::from_slice::<serde_json::Value>(body) {
+            Ok(json) => {
+                let masked_json = mask_json_value(json);
+                // Use compact serialization to match original formatting
+                serde_json::to_string(&masked_json)
+                    .unwrap_or_else(|_| String::from_utf8_lossy(body).into_owned())
+            }
+            Err(_) => String::from_utf8_lossy(body).into_owned(),
+        }
+    } else if ct.starts_with("application/x-www-form-urlencoded") {
+        let raw = String::from_utf8_lossy(body);
+        raw.split('&')
+            .map(|pair| {
+                if let Some((key, _value)) = pair.split_once('=') {
+                    if is_sensitive_key(key) {
+                        format!("{key}={MASK}")
+                    } else {
+                        pair.to_string()
+                    }
+                } else {
+                    pair.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("&")
+    } else {
+        String::from_utf8_lossy(body).into_owned()
+    }
+}
+
+/// Recursively walks a JSON value, masking sensitive object field values.
+fn mask_json_value(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let masked_map = map
+                .into_iter()
+                .map(|(k, v)| {
+                    let new_v = if is_sensitive_key(&k) {
+                        serde_json::Value::String(MASK.to_string())
+                    } else {
+                        mask_json_value(v)
+                    };
+                    (k, new_v)
+                })
+                .collect();
+            serde_json::Value::Object(masked_map)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(mask_json_value).collect())
+        }
+        other => other,
+    }
 }
 
 #[cfg(test)]
@@ -260,5 +341,85 @@ mod tests {
 
         set_mask_sensitive(true);
         assert!(should_mask_sensitive());
+    }
+
+    #[test]
+    fn test_mask_body_json_sensitive_keys() {
+        let body = br#"{"username":"alice","password":"hunter2","token":"abc123"}"#;
+        let masked = mask_body(body, Some("application/json"));
+        let v: serde_json::Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(v["username"], "alice");
+        assert_eq!(v["password"], "*****");
+        assert_eq!(v["token"], "*****");
+    }
+
+    #[test]
+    fn test_mask_body_json_no_sensitive_keys() {
+        let body = br#"{"name":"alice","age":30}"#;
+        let masked = mask_body(body, Some("application/json"));
+        let v: serde_json::Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(v["name"], "alice");
+        assert_eq!(v["age"], 30);
+    }
+
+    #[test]
+    fn test_mask_body_json_nested() {
+        let body = br#"{"user":{"password":"s3cr3t","name":"bob"}}"#;
+        let masked = mask_body(body, Some("application/json"));
+        let v: serde_json::Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(v["user"]["password"], "*****");
+        assert_eq!(v["user"]["name"], "bob");
+    }
+
+    #[test]
+    fn test_mask_body_json_case_insensitive_key() {
+        let body = br#"{"Password":"secret123"}"#;
+        let masked = mask_body(body, Some("application/json"));
+        let v: serde_json::Value = serde_json::from_str(&masked).unwrap();
+        assert_eq!(v["Password"], "*****");
+    }
+
+    #[test]
+    fn test_mask_body_json_content_type_with_charset() {
+        let body = br#"{"password":"s3cr3t"}"#;
+        let masked = mask_body(body, Some("application/json; charset=utf-8"));
+        assert!(masked.contains("\"*****\""));
+    }
+
+    #[test]
+    fn test_mask_body_json_invalid_falls_back_to_raw() {
+        let body = b"not valid json";
+        let masked = mask_body(body, Some("application/json"));
+        assert_eq!(masked, "not valid json");
+    }
+
+    #[test]
+    fn test_mask_body_form_urlencoded_sensitive() {
+        let body = b"username=alice&password=hunter2&token=abc";
+        let masked = mask_body(body, Some("application/x-www-form-urlencoded"));
+        assert!(masked.contains("username=alice"));
+        assert!(masked.contains("password=*****"));
+        assert!(masked.contains("token=*****"));
+    }
+
+    #[test]
+    fn test_mask_body_form_urlencoded_no_sensitive() {
+        let body = b"name=alice&age=30";
+        let masked = mask_body(body, Some("application/x-www-form-urlencoded"));
+        assert_eq!(masked, "name=alice&age=30");
+    }
+
+    #[test]
+    fn test_mask_body_plain_text_passthrough() {
+        let body = b"hello world";
+        let masked = mask_body(body, Some("text/plain"));
+        assert_eq!(masked, "hello world");
+    }
+
+    #[test]
+    fn test_mask_body_no_content_type_passthrough() {
+        let body = b"some raw bytes";
+        let masked = mask_body(body, None);
+        assert_eq!(masked, "some raw bytes");
     }
 }

--- a/tanu-core/src/reporter.rs
+++ b/tanu-core/src/reporter.rs
@@ -544,7 +544,6 @@ impl Reporter for ListReporter {
     }
 }
 
-
 fn symbol_test_result(test: &Test) -> StyledObject<&'static str> {
     match test.result {
         Ok(_) => symbol_success(),
@@ -559,7 +558,6 @@ fn symbol_success() -> StyledObject<&'static str> {
 fn symbol_error() -> StyledObject<&'static str> {
     style("✘").red()
 }
-
 
 /// Color HTTP methods for visual distinction
 fn style_http_method(method: &str) -> StyledObject<&str> {
@@ -624,6 +622,69 @@ fn style_module_path(module: &str, test: &str) -> String {
     format!("{}::{}", style(module).cyan(), style(test).blue().bold())
 }
 
+/// Recursively formats a JSON value with ANSI terminal colors.
+///
+/// Keys are rendered in bold cyan, strings in green, numbers in yellow,
+/// booleans in magenta, and null in dim. Structural characters are dim.
+fn colorize_json(value: &serde_json::Value, indent: usize) -> String {
+    let pad = "  ".repeat(indent);
+    let inner = "  ".repeat(indent + 1);
+    match value {
+        serde_json::Value::Null => style("null").dim().to_string(),
+        serde_json::Value::Bool(b) => style(b.to_string()).magenta().to_string(),
+        serde_json::Value::Number(n) => style(n.to_string()).yellow().to_string(),
+        serde_json::Value::String(s) => {
+            let repr = serde_json::to_string(s).unwrap_or_else(|_| format!("\"{s}\""));
+            style(repr).green().to_string()
+        }
+        serde_json::Value::Array(arr) => {
+            if arr.is_empty() {
+                return style("[]").dim().to_string();
+            }
+            let items: Vec<String> = arr
+                .iter()
+                .map(|v| format!("{}{}", inner, colorize_json(v, indent + 1)))
+                .collect();
+            let comma = style(",").dim().to_string();
+            format!(
+                "{}\n{}\n{}{}",
+                style("[").dim(),
+                items.join(&format!("{comma}\n")),
+                pad,
+                style("]").dim()
+            )
+        }
+        serde_json::Value::Object(map) => {
+            if map.is_empty() {
+                return style("{}").dim().to_string();
+            }
+            let items: Vec<String> = map
+                .iter()
+                .map(|(k, v)| {
+                    let key_repr = serde_json::to_string(k).unwrap_or_else(|_| format!("\"{k}\""));
+                    let key = style(key_repr).cyan().bold().to_string();
+                    let colon = style(":").dim().to_string();
+                    format!("{}{}{} {}", inner, key, colon, colorize_json(v, indent + 1))
+                })
+                .collect();
+            let comma = style(",").dim().to_string();
+            let open = style("{").dim().to_string();
+            let close = format!("{}{}", pad, style("}").dim());
+            format!("{}\n{}\n{}", open, items.join(&format!("{comma}\n")), close)
+        }
+    }
+}
+
+/// Formats a body string for terminal display. Parses and colorizes JSON when
+/// the content-type is `application/json`; otherwise returns the text as-is.
+fn format_body_for_display(body: &str, content_type: &str) -> String {
+    if content_type.to_lowercase().starts_with("application/json") {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
+            return colorize_json(&json, 0);
+        }
+    }
+    body.to_string()
+}
 
 fn write_http_log(terminal: &Term, log: &http::Log) -> eyre::Result<()> {
     terminal.write_line(&format!(
@@ -650,6 +711,24 @@ fn write_http_log(terminal: &Term, log: &http::Log) -> eyre::Result<()> {
             style(log.request.headers.get(key).unwrap().to_str().unwrap()).dim()
         ))?;
     }
+    if let Some(ref body) = log.request.body {
+        if !body.is_empty() {
+            terminal.write_line(&format!(
+                "    {} {}",
+                style(">").cyan(),
+                style("body:").dim()
+            ))?;
+            let req_ct = log
+                .request
+                .headers
+                .get("content-type")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            for line in format_body_for_display(body, req_ct).lines() {
+                terminal.write_line(&format!("       {}", line))?;
+            }
+        }
+    }
     terminal.write_line(&format!(
         "  {} {}",
         style("<").yellow(),
@@ -675,11 +754,21 @@ fn write_http_log(terminal: &Term, log: &http::Log) -> eyre::Result<()> {
         ))?;
     }
     terminal.write_line(&format!(
-        "    {} {} {}",
+        "    {} {}",
         style("<").yellow(),
-        style("body:").dim(),
-        style(&log.response.body).dim()
+        style("body:").dim()
     ))?;
+    if !log.response.body.is_empty() {
+        let res_ct = log
+            .response
+            .headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        for line in format_body_for_display(&log.response.body, res_ct).lines() {
+            terminal.write_line(&format!("       {}", line))?;
+        }
+    }
     Ok(())
 }
 

--- a/tanu-tui/src/widget/info.rs
+++ b/tanu-tui/src/widget/info.rs
@@ -648,30 +648,10 @@ impl InfoWidget {
 
         #[cfg(feature = "grpc")]
         let (theme_bg, highlighted_text) = match call {
-            SelectedCall::Http(http_call) => {
-                let body = &http_call.response.body;
-                if body.is_empty() {
-                    return;
-                }
-
-                let content_type = http_call
-                    .response
-                    .headers
-                    .get("content-type")
-                    .map(|v| v.to_str().unwrap_or_default());
-
-                if content_type == Some("application/json") {
-                    let json: serde_json::Value = match serde_json::from_str(body) {
-                        Ok(json) => json,
-                        Err(_) => return,
-                    };
-                    let json_str = serde_json::to_string_pretty(&json).unwrap();
-                    let (theme_bg, highlighted_json) = highlight_source_code(json_str);
-                    (Some(theme_bg), highlighted_json)
-                } else {
-                    (None, body.to_string())
-                }
-            }
+            SelectedCall::Http(http_call) => match build_http_payload_text(http_call) {
+                Some(result) => result,
+                None => return,
+            },
             SelectedCall::Grpc(grpc_call) => {
                 let req_msg = tanu_core::grpc::format_message(&grpc_call.request.message);
                 let res_msg = tanu_core::grpc::format_message(&grpc_call.response.message);
@@ -684,29 +664,9 @@ impl InfoWidget {
         };
 
         #[cfg(not(feature = "grpc"))]
-        let (theme_bg, highlighted_text) = {
-            let body = &call.response.body;
-            if body.is_empty() {
-                return;
-            }
-
-            let content_type = call
-                .response
-                .headers
-                .get("content-type")
-                .map(|v| v.to_str().unwrap_or_default());
-
-            if content_type == Some("application/json") {
-                let json: serde_json::Value = match serde_json::from_str(body) {
-                    Ok(json) => json,
-                    Err(_) => return,
-                };
-                let json_str = serde_json::to_string_pretty(&json).unwrap();
-                let (theme_bg, highlighted_json) = highlight_source_code(json_str);
-                (Some(theme_bg), highlighted_json)
-            } else {
-                (None, body.to_string())
-            }
+        let (theme_bg, highlighted_text) = match build_http_payload_text(call) {
+            Some(result) => result,
+            None => return,
         };
 
         // Split the highlighted JSON into lines
@@ -843,6 +803,80 @@ static THEME: Lazy<Theme> = Lazy::new(|| {
 
 // Include the generated themes module
 include!(concat!(env!("OUT_DIR"), "/themes.rs"));
+
+/// Formats a request body for display: pretty-prints if valid JSON and the
+/// content-type advertises JSON, otherwise returns the raw text unchanged.
+fn pretty_print_if_json(body: &str, content_type: &str) -> String {
+    if content_type.starts_with("application/json") {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(body) {
+            return serde_json::to_string_pretty(&json).unwrap_or_else(|_| body.to_string());
+        }
+    }
+    body.to_string()
+}
+
+/// Builds the payload panel text for an HTTP call.
+///
+/// Returns `None` when both the request and response bodies are empty (the
+/// panel should then be hidden). Returns `Some((theme_bg, text))` where
+/// `theme_bg` is set when syntax-highlighting was applied.
+///
+/// Behaviour:
+/// - If there is **no request body**, mirrors the original behaviour: JSON
+///   response bodies are syntax-highlighted; others are shown as plain text.
+/// - If a **request body is present**, both bodies are shown under labelled
+///   sections ("Request Body:" / "Response Body:") without syntax highlighting,
+///   mirroring the gRPC combined-message display.
+fn build_http_payload_text(
+    http_call: &tanu_core::http::Log,
+) -> Option<(Option<syntect::highlighting::Color>, String)> {
+    let req_body = http_call.request.body.as_deref().unwrap_or("").trim();
+    let res_body = http_call.response.body.trim();
+
+    if req_body.is_empty() && res_body.is_empty() {
+        return None;
+    }
+
+    // No request body — keep original behaviour for response-only display.
+    if req_body.is_empty() {
+        let content_type = http_call
+            .response
+            .headers
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if content_type.starts_with("application/json") {
+            let json: serde_json::Value = serde_json::from_str(res_body).ok()?;
+            let json_str = serde_json::to_string_pretty(&json).unwrap();
+            let (theme_bg, highlighted_json) = highlight_source_code(json_str);
+            return Some((Some(theme_bg), highlighted_json));
+        }
+        return Some((None, res_body.to_string()));
+    }
+
+    // Request body present — build a combined section display.
+    let req_ct = http_call
+        .request
+        .headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let res_ct = http_call
+        .response
+        .headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    let mut text = format!("Request Body:\n{}", pretty_print_if_json(req_body, req_ct));
+    if !res_body.is_empty() {
+        text.push_str(&format!(
+            "\n\nResponse Body:\n{}",
+            pretty_print_if_json(res_body, res_ct)
+        ));
+    }
+    Some((None, text))
+}
 
 #[memoize::memoize]
 fn highlight_source_code(source_code: String) -> (syntect::highlighting::Color, String) {

--- a/tanu-tui/src/widget/list.rs
+++ b/tanu-tui/src/widget/list.rs
@@ -924,6 +924,7 @@ mod test {
                         url: "https://example.com/1".parse()?,
                         method: http::Method::GET,
                         headers: http::header::HeaderMap::new(),
+                        body: None,
                     },
                     response: tanu_core::http::LogResponse {
                         status: StatusCode::OK,
@@ -937,6 +938,7 @@ mod test {
                         url: "https://example.com/2".parse()?,
                         method: http::Method::GET,
                         headers: http::header::HeaderMap::new(),
+                        body: None,
                     },
                     response: tanu_core::http::LogResponse {
                         status: StatusCode::OK,

--- a/tanu/src/app.rs
+++ b/tanu/src/app.rs
@@ -314,10 +314,11 @@ impl App {
                 reporters.extend([(
                     ReporterType::List.to_string(),
                     Box::new(ListReporter::new(capture_http)),
-                )] as [(
-                    String,
-                    Box<dyn tanu_core::reporter::Reporter + 'static + Send>,
-                ); 1]);
+                )]
+                    as [(
+                        String,
+                        Box<dyn tanu_core::reporter::Reporter + 'static + Send>,
+                    ); 1]);
 
                 for reporter in reporters_arg {
                     runner.add_boxed_reporter(


### PR DESCRIPTION
Add request body capture, masking, and display to the --capture-http feature. The body is stored on LogRequest as Option<String>, masked for sensitive JSON/form keys when masking is enabled, and rendered in both the CLI reporter (with per-line indentation and ANSI JSON colors) and the TUI payload panel (combined request + response view).