### PR TITLE
🐛 Fix clippy drain_collect errors in reporter

### DIFF
--- a/tanu-core/src/reporter.rs
+++ b/tanu-core/src/reporter.rs
@@ -411,9 +411,9 @@ impl Reporter for ListReporter {
             .ok_or_else(|| eyre::eyre!("test case \"{test_name}\" not found in the buffer",))?;
 
         let test_number = *buffer.test_number.get_or_insert_with(generate_test_number);
-        let http_logs: Vec<_> = buffer.http_logs.drain(..).collect();
+        let http_logs = std::mem::take(&mut buffer.http_logs);
         #[cfg(feature = "grpc")]
-        let grpc_logs: Vec<_> = buffer.grpc_logs.drain(..).collect();
+        let grpc_logs = std::mem::take(&mut buffer.grpc_logs);
 
         if let Err(e) = test.result {
             self.terminal.write_line(&format!(


### PR DESCRIPTION
## Summary

CI clippy (`--deny clippy::all`) is failing on `main` with two `clippy::drain_collect` errors introduced in #184:

```
error: draining all elements of a collection into a new collection of the same type
   --> tanu-core/src/reporter.rs:414:33
   --> tanu-core/src/reporter.rs:416:33
```

Replaces `buffer.<field>.drain(..).collect()` with `std::mem::take(&mut buffer.<field>)`. Same semantics (the buffer is left empty) without the extra allocation.

Note: this lint doesn't fire on clippy 0.1.96, only on the newer stable used by CI — hence it slipped through locally.

## Testing

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --features "json,multipart,cookies,grpc,graphql,native-tls" -- --deny clippy::all` ✅
- `cargo clippy --workspace --all-targets --no-default-features --features "json,multipart,cookies,grpc,graphql,rustls-tls-webpki-roots" -- --deny clippy::all` ✅
- `cargo build --workspace --all-targets` for both feature sets ✅
- `TANU_CONFIG=./tanu-integration-tests/tanu.toml cargo run -p tanu-integration-tests -- test` → 205 passed, 0 failed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)